### PR TITLE
Relax spawn_after parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - CI changelog entry enforcer
 
+### Changed
+
+- `spawn_after` now takes an `Into<Duration>` instead of bare `Duration`
+
 ## [v1.0.0] - 2021-12-25
 
 ### Changed

--- a/macros/src/codegen/module.rs
+++ b/macros/src/codegen/module.rs
@@ -376,14 +376,15 @@ pub fn codegen(
                 /// This will use the time `Instant::new(0)` as baseline if called in `#[init]`,
                 /// so if you use a non-resetable timer use `spawn_at` when in `#[init]`
                 #[allow(non_snake_case)]
-                pub fn #internal_spawn_after_ident(
-                    duration: <#m as rtic::Monotonic>::Duration
+                pub fn #internal_spawn_after_ident<D>(
+                    duration: D
                     #(,#args)*
                 ) -> Result<#name::#m::SpawnHandle, #ty>
+                where D: Into<<#m as rtic::Monotonic>::Duration>
                 {
                     let instant = monotonics::#m::now();
 
-                    #internal_spawn_at_ident(instant + duration #(,#untupled)*)
+                    #internal_spawn_at_ident(instant + duration.into() #(,#untupled)*)
                 }
 
                 #(#cfgs)*


### PR DESCRIPTION
With RTIC 1.0 if you use `embedded_time` on your `Monotonic` impl any call to `task::spawn_after(...)` has to put a `.into()` after the time type.
```rust
task::spawn_after(Milliseconds(250).into())
```
This is because the implementation of `Monotonic` requires using `embedded_time::duration::Generic` for the `Duration` associated type. This PR changes the bounds on the `spawn_after` function to take any type that can be converted into the target duration type. Removing the need to type all the `into()`s.

There are some backward-compatibility concerns since any code that previously used .into() will now fail the type inference. I'm also not sure how this affects the type inference for any `Monotonic` using `fugit` since I don't have a firmware repo to test with that.