### PR TITLE
fix(rtic-sync): used fully qualified paths in Channel Macro

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -16,5 +16,6 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Fixed
 
 - Unmask the `rp2040` interrupt
+- Use `$crate` and fully qualified paths in macros 
 
 ## [v1.0.0] - 2023-xx-xx

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -144,12 +144,12 @@ macro_rules! make_rp2040_monotonic_handler {
         #[no_mangle]
         #[allow(non_snake_case)]
         unsafe extern "C" fn TIMER_IRQ_0() {
-            rtic_monotonics::rp2040::Timer::__tq().on_monotonic_interrupt();
+            $crate::rp2040::Timer::__tq().on_monotonic_interrupt();
         }
 
         pub struct Rp2040Token;
 
-        unsafe impl rtic_monotonics::InterruptToken<rtic_monotonics::rp2040::Timer>
+        unsafe impl $crate::InterruptToken<rtic_monotonics::rp2040::Timer>
             for Rp2040Token
         {
         }

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -149,7 +149,7 @@ macro_rules! make_rp2040_monotonic_handler {
 
         pub struct Rp2040Token;
 
-        unsafe impl $crate::InterruptToken<rtic_monotonics::rp2040::Timer>
+        unsafe impl $crate::InterruptToken<$crate::rp2040::Timer>
             for Rp2040Token
         {
         }

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -139,8 +139,7 @@ impl embedded_hal_async::delay::DelayUs for Timer {
 /// Register the Timer interrupt for the monotonic.
 #[macro_export]
 macro_rules! make_rp2040_monotonic_handler {
-    () => {
-    {
+    () => {{
         #[no_mangle]
         #[allow(non_snake_case)]
         unsafe extern "C" fn TIMER_IRQ_0() {
@@ -149,12 +148,8 @@ macro_rules! make_rp2040_monotonic_handler {
 
         pub struct Rp2040Token;
 
-        unsafe impl $crate::InterruptToken<$crate::rp2040::Timer>
-            for Rp2040Token
-        {
-        }
+        unsafe impl $crate::InterruptToken<$crate::rp2040::Timer> for Rp2040Token {}
 
         Rp2040Token
-    }
-    };
+    }};
 }

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -167,7 +167,7 @@ macro_rules! make_systick_handler {
 
         pub struct SystickToken;
 
-        unsafe impl $crate::InterruptToken<rtic_monotonics::systick::Systick>
+        unsafe impl $crate::InterruptToken<$crate::systick::Systick>
             for SystickToken
         {
         }

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -162,12 +162,12 @@ macro_rules! make_systick_handler {
         #[no_mangle]
         #[allow(non_snake_case)]
         unsafe extern "C" fn SysTick() {
-            rtic_monotonics::systick::Systick::__tq().on_monotonic_interrupt();
+            $crate::systick::Systick::__tq().on_monotonic_interrupt();
         }
 
         pub struct SystickToken;
 
-        unsafe impl rtic_monotonics::InterruptToken<rtic_monotonics::systick::Systick>
+        unsafe impl $crate::InterruptToken<rtic_monotonics::systick::Systick>
             for SystickToken
         {
         }

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -157,8 +157,7 @@ impl embedded_hal_async::delay::DelayUs for Systick {
 /// Register the Systick interrupt for the monotonic.
 #[macro_export]
 macro_rules! make_systick_handler {
-    () => {
-    {
+    () => {{
         #[no_mangle]
         #[allow(non_snake_case)]
         unsafe extern "C" fn SysTick() {
@@ -167,12 +166,8 @@ macro_rules! make_systick_handler {
 
         pub struct SystickToken;
 
-        unsafe impl $crate::InterruptToken<$crate::systick::Systick>
-            for SystickToken
-        {
-        }
+        unsafe impl $crate::InterruptToken<$crate::systick::Systick> for SystickToken {}
 
         SystickToken
-    }
-    };
+    }};
 }

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -103,7 +103,7 @@ impl<T, const N: usize> Channel<T, N> {
 #[macro_export]
 macro_rules! make_channel {
     ($type:path, $size:expr) => {{
-        static mut CHANNEL: ::rtic_sync::channel::Channel<$type, $size> = ::rtic_sync::channel::Channel::new();
+        static mut CHANNEL: $crate::channel::Channel<$type, $size> = $crate::channel::Channel::new();
 
         // SAFETY: This is safe as we hide the static mut from others to access it.
         // Only this point is where the mutable access happens.

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -102,7 +102,7 @@ impl<T, const N: usize> Channel<T, N> {
 #[macro_export]
 macro_rules! make_channel {
     ($type:path, $size:expr) => {{
-        static mut CHANNEL: Channel<$type, $size> = Channel::new();
+        static mut CHANNEL: ::rtic_sync::channel::Channel<$type, $size> = ::rtic_sync::channel::Channel::new();
 
         // SAFETY: This is safe as we hide the static mut from others to access it.
         // Only this point is where the mutable access happens.

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -103,7 +103,8 @@ impl<T, const N: usize> Channel<T, N> {
 #[macro_export]
 macro_rules! make_channel {
     ($type:path, $size:expr) => {{
-        static mut CHANNEL: $crate::channel::Channel<$type, $size> = $crate::channel::Channel::new();
+        static mut CHANNEL: $crate::channel::Channel<$type, $size> =
+            $crate::channel::Channel::new();
 
         // SAFETY: This is safe as we hide the static mut from others to access it.
         // Only this point is where the mutable access happens.
@@ -125,8 +126,8 @@ pub enum TrySendError<T> {
 }
 
 impl<T> core::fmt::Debug for NoReceiver<T>
-    where
-        T: core::fmt::Debug,
+where
+    T: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "NoReceiver({:?})", self.0)
@@ -134,8 +135,8 @@ impl<T> core::fmt::Debug for NoReceiver<T>
 }
 
 impl<T> core::fmt::Debug for TrySendError<T>
-    where
-        T: core::fmt::Debug,
+where
+    T: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -146,8 +147,8 @@ impl<T> core::fmt::Debug for TrySendError<T>
 }
 
 impl<T> PartialEq for TrySendError<T>
-    where
-        T: PartialEq,
+where
+    T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -301,7 +302,7 @@ impl<'a, T, const N: usize> Sender<'a, T, N> {
                 Poll::Pending
             }
         })
-            .await;
+        .await;
 
         // Make sure the link is removed from the queue.
         drop(dropper);
@@ -431,7 +432,7 @@ impl<'a, T, const N: usize> Receiver<'a, T, N> {
 
             Poll::Pending
         })
-            .await
+        .await
     }
 
     /// Returns true if there are no `Sender`s.

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -38,6 +38,7 @@ pub struct Channel<T, const N: usize> {
 }
 
 unsafe impl<T, const N: usize> Send for Channel<T, N> {}
+
 unsafe impl<T, const N: usize> Sync for Channel<T, N> {}
 
 struct UnsafeAccess<'a, const N: usize> {
@@ -124,8 +125,8 @@ pub enum TrySendError<T> {
 }
 
 impl<T> core::fmt::Debug for NoReceiver<T>
-where
-    T: core::fmt::Debug,
+    where
+        T: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "NoReceiver({:?})", self.0)
@@ -133,8 +134,8 @@ where
 }
 
 impl<T> core::fmt::Debug for TrySendError<T>
-where
-    T: core::fmt::Debug,
+    where
+        T: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -145,8 +146,8 @@ where
 }
 
 impl<T> PartialEq for TrySendError<T>
-where
-    T: PartialEq,
+    where
+        T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -176,6 +177,7 @@ impl LinkPtr {
 }
 
 unsafe impl Send for LinkPtr {}
+
 unsafe impl Sync for LinkPtr {}
 
 impl<'a, T, const N: usize> core::fmt::Debug for Sender<'a, T, N> {
@@ -299,7 +301,7 @@ impl<'a, T, const N: usize> Sender<'a, T, N> {
                 Poll::Pending
             }
         })
-        .await;
+            .await;
 
         // Make sure the link is removed from the queue.
         drop(dropper);
@@ -429,7 +431,7 @@ impl<'a, T, const N: usize> Receiver<'a, T, N> {
 
             Poll::Pending
         })
-        .await
+            .await
     }
 
     /// Returns true if there are no `Sender`s.


### PR DESCRIPTION
Other imports with the name `Channel` (e.g. from Embassy) broke this macro. Now they don't.