### PR TITLE
cortex-m as optional dependency

### DIFF
--- a/rtic-macros/src/codegen/async_dispatchers.rs
+++ b/rtic-macros/src/codegen/async_dispatchers.rs
@@ -42,7 +42,7 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
             let device = &app.args.device;
             let enum_ = util::interrupt_ident();
 
-            quote!(rtic::pend(#device::#enum_::#dispatcher_name);)
+            quote!(rtic::export::pend(#device::#enum_::#dispatcher_name);)
         } else {
             // For 0 priority tasks we don't need to pend anything
             quote!()

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -141,7 +141,7 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
             let device = &app.args.device;
             let enum_ = util::interrupt_ident();
             let interrupt = &analysis.interrupts.get(&priority).expect("UREACHABLE").0;
-            quote!(rtic::pend(#device::#enum_::#interrupt);)
+            quote!(rtic::export::pend(#device::#enum_::#interrupt);)
         } else {
             quote!()
         };

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -13,6 +13,9 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- `cortex-m` set as an optional dependency
+- Moved `cortex-m`-related utilities from `rtic/lib.rs` to `rtic/export.rs`
+
 ## [v1.1.4] - 2023-02-26
 
 ### Added

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -34,7 +34,7 @@ version = "2.0.0-alpha.0"
 name = "rtic"
 
 [dependencies]
-cortex-m = "0.7.0"
+cortex-m = { version = "0.7.0", optional = true }
 bare-metal = "1.0.0"
 #portable-atomic = { version = "0.3.19" }
 atomic-polyfill = "1"
@@ -65,17 +65,17 @@ trybuild = "1"
 [features]
 default = []
 
-thumbv6-backend = ["rtic-macros/cortex-m-source-masking"]
-thumbv7-backend = ["rtic-macros/cortex-m-basepri"]
-thumbv8base-backend = ["rtic-macros/cortex-m-source-masking"]
-thumbv8main-backend = ["rtic-macros/cortex-m-basepri"]
+thumbv6-backend = ["cortex-m", "rtic-macros/cortex-m-source-masking"]
+thumbv7-backend = ["cortex-m", "rtic-macros/cortex-m-basepri"]
+thumbv8base-backend = ["cortex-m", "rtic-macros/cortex-m-source-masking"]
+thumbv8main-backend = ["cortex-m", "rtic-macros/cortex-m-basepri"]
 # riscv-clic-backend = ["rtic-macros/riscv-clic"]
 # riscv-ch32-backend = ["rtic-macros/riscv-ch32"]
 # riscv-esp32c3-backend = ["rtic-macros/riscv-esp32c3"]
 
 # needed for testing
-rtic-uitestv7 = ["thumbv7-backend", "rtic-macros/cortex-m-basepri"]
-rtic-uitestv6 = ["thumbv6-backend", "rtic-macros/cortex-m-source-masking"]
+rtic-uitestv7 = ["thumbv7-backend"]
+rtic-uitestv6 = ["thumbv6-backend"]
 test-critical-section = ["cortex-m/critical-section-single-core", "rtic-monotonics/systick-100hz"]
 
 # [[example]]

--- a/rtic/src/export.rs
+++ b/rtic/src/export.rs
@@ -32,13 +32,23 @@ pub use cortex_source_mask::*;
 #[cfg(any(feature = "cortex-m-source-masking", feature = "rtic-uitestv6"))]
 mod cortex_source_mask;
 
+#[cfg(feature = "cortex-m")]
+pub use cortex_m::{interrupt::InterruptNumber, peripheral::NVIC};
+
+/// Sets the given `interrupt` as pending
+///
+/// This is a convenience function around
+/// [`NVIC::pend`](../cortex_m/peripheral/struct.NVIC.html#method.pend)
+#[cfg(feature = "cortex-m")]
+pub fn pend<I>(interrupt: I)
+where
+    I: InterruptNumber,
+{
+    NVIC::pend(interrupt);
+}
+
 /// Priority conversion, takes logical priorities 1..=N and converts it to NVIC priority.
-#[cfg(any(
-    feature = "cortex-m-basepri",
-    feature = "cortex-m-source-masking",
-    feature = "rtic-uitestv6",
-    feature = "rtic-uitestv7",
-))]
+#[cfg(feature = "cortex-m")]
 #[inline]
 #[must_use]
 pub const fn cortex_logical2hw(logical: u8, nvic_prio_bits: u8) -> u8 {

--- a/rtic/src/lib.rs
+++ b/rtic/src/lib.rs
@@ -33,7 +33,6 @@
 //deny_warnings_placeholder_for_ci
 #![allow(clippy::inline_always)]
 
-use cortex_m::{interrupt::InterruptNumber, peripheral::NVIC};
 pub use rtic_core::{prelude as mutex_prelude, Exclusive, Mutex};
 pub use rtic_macros::app;
 // pub use rtic_monotonic::{self, Monotonic};
@@ -47,16 +46,8 @@ pub mod mutex {
 #[doc(hidden)]
 pub mod export;
 
-/// Sets the given `interrupt` as pending
-///
-/// This is a convenience function around
-/// [`NVIC::pend`](../cortex_m/peripheral/struct.NVIC.html#method.pend)
-pub fn pend<I>(interrupt: I)
-where
-    I: InterruptNumber,
-{
-    NVIC::pend(interrupt);
-}
+#[cfg(feature = "cortex-m")]
+pub use export::pend;
 
 use core::cell::UnsafeCell;
 


### PR DESCRIPTION
Now, `cortex-m` is an optional dependency. I also moved `pend` from `rtic/lib.rs` to `rtic/export.rs`, which is under a feature gate. I re-exported this function to avoid breaking previous examples.