### PR TITLE
Removed device from init context in preparation for its disapearance

### DIFF
--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -21,17 +21,6 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
                 pub core: rtic::export::Peripherals
             ));
 
-            if app.args.peripherals {
-                let device = &app.args.device;
-
-                fields.push(quote!(
-                    /// Device peripherals (PAC)
-                    pub device: #device::Peripherals
-                ));
-
-                values.push(quote!(device: #device::Peripherals::steal()));
-            }
-
             fields.push(quote!(
                 /// Critical section token for init
                 pub cs: rtic::export::CriticalSection<'a>

--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -56,9 +56,6 @@ pub struct AppArgs {
     /// Device
     pub device: Path,
 
-    /// Peripherals
-    pub peripherals: bool,
-
     /// Interrupts used to dispatch software tasks
     pub dispatchers: Dispatchers,
 }

--- a/rtic-macros/src/syntax/parse/app.rs
+++ b/rtic-macros/src/syntax/parse/app.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use syn::{
     parse::{self, ParseStream, Parser},
     spanned::Spanned,
-    Expr, ExprArray, Fields, ForeignItem, Ident, Item, LitBool, Path, Token, Visibility,
+    Expr, ExprArray, Fields, ForeignItem, Ident, Item, Path, Token, Visibility,
 };
 
 use super::Input;
@@ -23,7 +23,6 @@ impl AppArgs {
         (|input: ParseStream<'_>| -> parse::Result<Self> {
             let mut custom = Set::new();
             let mut device = None;
-            let mut peripherals = true;
             let mut dispatchers = Dispatchers::new();
 
             loop {
@@ -54,17 +53,6 @@ impl AppArgs {
                             return Err(parse::Error::new(
                                 ident.span(),
                                 "unexpected argument value; this should be a path",
-                            ));
-                        }
-                    }
-
-                    "peripherals" => {
-                        if let Ok(p) = input.parse::<LitBool>() {
-                            peripherals = p.value;
-                        } else {
-                            return Err(parse::Error::new(
-                                ident.span(),
-                                "unexpected argument value; this should be a boolean",
                             ));
                         }
                     }
@@ -133,7 +121,6 @@ impl AppArgs {
 
             Ok(AppArgs {
                 device,
-                peripherals,
                 dispatchers,
             })
         })

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -13,6 +13,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- `peripherals = ...` is removed
+- The context in init has removed `cx.device`
 - `cortex-m` set as an optional dependency
 - Moved `cortex-m`-related utilities from `rtic/lib.rs` to `rtic/export.rs`
 - Make async task priorities start at 0, instead of 1, to always start at the lowest priority

--- a/rtic/examples/async-delay.rs
+++ b/rtic/examples/async-delay.rs
@@ -9,7 +9,7 @@
 
 use panic_semihosting as _;
 
-#[rtic::app(device = lm3s6965, dispatchers = [SSI0, UART0], peripherals = true)]
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0, UART0])]
 mod app {
     use cortex_m_semihosting::{debug, hprintln};
     use rtic_monotonics::systick::*;

--- a/rtic/examples/async-task.rs
+++ b/rtic/examples/async-task.rs
@@ -15,7 +15,7 @@ use panic_semihosting as _;
 //   task can have a mutable reference stored.
 // - Spawning an async task equates to it being polled once.
 
-#[rtic::app(device = lm3s6965, dispatchers = [SSI0, UART0], peripherals = true)]
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0, UART0])]
 mod app {
     use cortex_m_semihosting::{debug, hprintln};
 

--- a/rtic/examples/async-timeout.rs
+++ b/rtic/examples/async-timeout.rs
@@ -11,7 +11,7 @@ use cortex_m_semihosting::{debug, hprintln};
 use panic_semihosting as _;
 use rtic_monotonics::systick::*;
 
-#[rtic::app(device = lm3s6965, dispatchers = [SSI0, UART0], peripherals = true)]
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0, UART0])]
 mod app {
     use super::*;
     use futures::{future::FutureExt, select_biased};

--- a/rtic/examples/init.rs
+++ b/rtic/examples/init.rs
@@ -8,7 +8,7 @@
 
 use panic_semihosting as _;
 
-#[rtic::app(device = lm3s6965, peripherals = true)]
+#[rtic::app(device = lm3s6965)]
 mod app {
     use cortex_m_semihosting::{debug, hprintln};
 
@@ -22,9 +22,6 @@ mod app {
     fn init(cx: init::Context) -> (Shared, Local) {
         // Cortex-M peripherals
         let _core: cortex_m::Peripherals = cx.core;
-
-        // Device specific peripherals
-        let _device: lm3s6965::Peripherals = cx.device;
 
         // Locals in `init` have 'static lifetime
         let _x: &'static mut u32 = cx.local.x;

--- a/rtic/examples/zero-prio-task.rs
+++ b/rtic/examples/zero-prio-task.rs
@@ -15,7 +15,7 @@ pub struct NotSend {
     _0: PhantomData<*const ()>,
 }
 
-#[rtic::app(device = lm3s6965, peripherals = true)]
+#[rtic::app(device = lm3s6965)]
 mod app {
     use super::NotSend;
     use core::marker::PhantomData;


### PR DESCRIPTION
As hinted by @dirbaio, the peripherals singleton is probably being removed from svd2rust.
Testing how it looks if we remove all internal use of the singletons.

Related PR: https://github.com/rust-embedded/svd2rust/issues/714