### PR TITLE
allow #[init] and #[idle] to be externed

### DIFF
--- a/rtic-macros/src/codegen/idle.rs
+++ b/rtic-macros/src/codegen/idle.rs
@@ -34,16 +34,20 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
         let attrs = &idle.attrs;
         let context = &idle.context;
         let stmts = &idle.stmts;
-        let user_idle = Some(quote!(
-            #(#attrs)*
-            #[allow(non_snake_case)]
-            fn #name(#context: #name::Context) -> ! {
-                use rtic::Mutex as _;
-                use rtic::mutex::prelude::*;
+        let user_idle = if !idle.is_extern {
+            Some(quote!(
+                #(#attrs)*
+                #[allow(non_snake_case)]
+                fn #name(#context: #name::Context) -> ! {
+                    use rtic::Mutex as _;
+                    use rtic::mutex::prelude::*;
 
-                #(#stmts)*
-            }
-        ));
+                    #(#stmts)*
+                }
+            ))
+        } else {
+            None
+        };
 
         quote!(
             #(#mod_app)*

--- a/rtic-macros/src/codegen/init.rs
+++ b/rtic-macros/src/codegen/init.rs
@@ -54,10 +54,12 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
         .collect();
 
     root_init.push(quote! {
+        #[doc = r"Shared resources"]
         #shared_vis struct #shared {
             #(#shared_resources)*
         }
 
+        #[doc = r"Local resources"]
         #local_vis struct #local {
             #(#local_resources)*
         }
@@ -67,14 +69,18 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
 
     let user_init_return = quote! {#shared, #local};
 
-    let user_init = quote!(
-        #(#attrs)*
-        #[inline(always)]
-        #[allow(non_snake_case)]
-        fn #name(#context: #name::Context) -> (#user_init_return) {
-            #(#stmts)*
-        }
-    );
+    let user_init = if !init.is_extern {
+        Some(quote!(
+            #(#attrs)*
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            fn #name(#context: #name::Context) -> (#user_init_return) {
+                #(#stmts)*
+            }
+        ))
+    } else {
+        None
+    };
 
     let mut mod_app = None;
 

--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -91,6 +91,9 @@ pub struct Init {
 
     /// The name of the user provided local resources struct
     pub user_local_struct: Ident,
+
+    /// The init function is declared externally
+    pub is_extern: bool,
 }
 
 /// `init` context metadata
@@ -127,6 +130,9 @@ pub struct Idle {
 
     /// The statements that make up this `idle` function
     pub stmts: Vec<Stmt>,
+
+    /// The idle function is declared externally
+    pub is_extern: bool,
 }
 
 /// `idle` context metadata

--- a/rtic-macros/src/syntax/parse/idle.rs
+++ b/rtic-macros/src/syntax/parse/idle.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{parse, ItemFn};
+use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
 use crate::syntax::{
     ast::{Idle, IdleArgs},
@@ -29,6 +29,35 @@ impl Idle {
                         context,
                         name: item.sig.ident,
                         stmts: item.block.stmts,
+                        is_extern: false,
+                    });
+                }
+            }
+        }
+
+        Err(parse::Error::new(
+            item.sig.ident.span(),
+            format!("this `#[idle]` function must have signature `fn({name}::Context) -> !`"),
+        ))
+    }
+
+    pub(crate) fn parse_foreign(args: IdleArgs, item: ForeignItemFn) -> parse::Result<Self> {
+        let valid_signature = util::check_foreign_fn_signature(&item, false)
+            && item.sig.inputs.len() == 1
+            && util::type_is_bottom(&item.sig.output);
+
+        let name = item.sig.ident.to_string();
+
+        if valid_signature {
+            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+                if rest.is_empty() {
+                    return Ok(Idle {
+                        args,
+                        attrs: item.attrs,
+                        context,
+                        name: item.sig.ident,
+                        stmts: Vec::<Stmt>::new(),
+                        is_extern: true,
                     });
                 }
             }

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -8,6 +8,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ## [Unreleased]
 
 ### Added
+- Allow #[init] and #[idle] to be defined externally
 
 ### Fixed
 

--- a/rtic/examples/extern_binds.rs
+++ b/rtic/examples/extern_binds.rs
@@ -6,8 +6,30 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 
-use cortex_m_semihosting::hprintln;
+use cortex_m_semihosting::{debug, hprintln};
+use lm3s6965::Interrupt;
 use panic_semihosting as _;
+
+// Free function implementing `init`.
+fn init(_: app::init::Context) -> (app::Shared, app::Local) {
+    rtic::pend(Interrupt::UART0);
+
+    hprintln!("init");
+
+    (app::Shared {}, app::Local {})
+}
+
+// Free function implementing `idle`.
+fn idle(_: app::idle::Context) -> ! {
+    hprintln!("idle");
+
+    rtic::pend(Interrupt::UART0);
+
+    loop {
+        cortex_m::asm::nop();
+        debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator
+    }
+}
 
 // Free function implementing the interrupt bound task `foo`.
 fn foo(_: app::foo::Context) {
@@ -16,38 +38,21 @@ fn foo(_: app::foo::Context) {
 
 #[rtic::app(device = lm3s6965)]
 mod app {
-    use crate::foo;
-    use cortex_m_semihosting::{debug, hprintln};
-    use lm3s6965::Interrupt;
+    use crate::{foo, idle, init};
 
     #[shared]
-    struct Shared {}
+    pub struct Shared {}
 
     #[local]
-    struct Local {}
-
-    #[init]
-    fn init(_: init::Context) -> (Shared, Local) {
-        rtic::pend(Interrupt::UART0);
-
-        hprintln!("init");
-
-        (Shared {}, Local {})
-    }
-
-    #[idle]
-    fn idle(_: idle::Context) -> ! {
-        hprintln!("idle");
-
-        rtic::pend(Interrupt::UART0);
-
-        loop {
-            cortex_m::asm::nop();
-            debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator
-        }
-    }
+    pub struct Local {}
 
     extern "Rust" {
+        #[init]
+        fn init(_: init::Context) -> (Shared, Local);
+
+        #[idle]
+        fn idle(_: idle::Context) -> !;
+
         #[task(binds = UART0)]
         fn foo(_: foo::Context);
     }


### PR DESCRIPTION
I updated `rtic-macros` to a allow init and idle to be externally defined.

## Design notes
* Updated `extern_binds` example to include external #[init] and #[idle] functions.
* Added docs to Local and Shared structs. The `extern_binds` example has a `#![deny(missing_docs)]` which caused some issues.

## Testing
Apart from building the example, I also used this feature in one of my projects and ran it on a MCU [here](https://github.com/grupacosmo/cansat/blob/98ca7bd42e737adfb140a548da1ade01beb495da/crates/cansat-stm32f4/src/main.rs#L59-L74)

## Related issues
* https://github.com/rtic-rs/rtic/issues/505

## Related PRs
* https://github.com/rtic-rs/rtic-syntax/pull/71