### PR TITLE
ritc-sync: Fix make_channel forcing dependency into user crate

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -13,6 +13,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- `make_channel` no longer requires the user crate to have `critical_section` in scope
+
 ## [v1.0.1] - 2023-06-14
 
 ### Fixed

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -9,6 +9,8 @@ use core::{
     sync::atomic::{fence, Ordering},
     task::{Poll, Waker},
 };
+#[doc(hidden)]
+pub use critical_section;
 use heapless::Deque;
 use rtic_common::waker_registration::CriticalSectionWakerRegistration as WakerRegistration;
 use rtic_common::{
@@ -108,7 +110,7 @@ macro_rules! make_channel {
 
         static CHECK: ::core::sync::atomic::AtomicU8 = ::core::sync::atomic::AtomicU8::new(0);
 
-        critical_section::with(|_| {
+        $crate::channel::critical_section::with(|_| {
             if CHECK.load(::core::sync::atomic::Ordering::Relaxed) != 0 {
                 panic!("call to the same `make_channel` instance twice");
             }


### PR DESCRIPTION
Before, `make_channel` assumed that `critical_section` would be available in the namespace of the code that invoked the macro. Access `critical_section` through `rtic-sync` instead.