### PR TITLE
Removing `nop` from the generated empty idle

### DIFF
--- a/rtic-macros/src/codegen/main.rs
+++ b/rtic-macros/src/codegen/main.rs
@@ -20,7 +20,6 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
         quote!(#dispatcher();)
     } else {
         quote!(loop {
-            rtic::export::nop()
         })
     };
 

--- a/rtic/src/export/cortex_basepri.rs
+++ b/rtic/src/export/cortex_basepri.rs
@@ -1,7 +1,6 @@
 use super::cortex_logical2hw;
 use cortex_m::register::basepri;
 pub use cortex_m::{
-    asm::nop,
     asm::wfi,
     interrupt,
     peripheral::{scb::SystemHandler, DWT, NVIC, SCB, SYST},

--- a/rtic/src/export/cortex_source_mask.rs
+++ b/rtic/src/export/cortex_source_mask.rs
@@ -1,5 +1,4 @@
 pub use cortex_m::{
-    asm::nop,
     asm::wfi,
     interrupt,
     peripheral::{scb::SystemHandler, DWT, NVIC, SCB, SYST},

--- a/rtic/src/export/riscv_esp32c3.rs
+++ b/rtic/src/export/riscv_esp32c3.rs
@@ -1,6 +1,6 @@
 use esp32c3::INTERRUPT_CORE0; //priority threshold control
 pub use esp32c3::{Interrupt, Peripherals};
-pub use riscv::{asm::nop, interrupt, register::mcause}; //low level interrupt enable/disable
+pub use riscv::{interrupt, register::mcause}; //low level interrupt enable/disable
 
 #[cfg(all(feature = "riscv-esp32c3", not(feature = "riscv-esp32c3-backend")))]
 compile_error!("Building for the esp32c3, but 'riscv-esp32c3-backend not selected'");


### PR DESCRIPTION
This addresses #747 , the empty ` loop{} ` turning into a UDF instruction has been fixed ( https://github.com/rust-lang/rust/issues/28728 ), so we can avoid exporting ` nop `. Unsure if this warrants a changelog entry.