### PR TITLE
rtic-sync: Add SPI bus sharing with arbiter

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -9,6 +9,8 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Added
 
+- `arbiter::spi::ArbiterDevice` for sharing SPI buses using `embedded-hal-async`
+
 ### Changed
 
 ### Fixed

--- a/rtic-sync/Cargo.toml
+++ b/rtic-sync/Cargo.toml
@@ -21,6 +21,9 @@ heapless = "0.7"
 critical-section = "1"
 rtic-common = { version = "1.0.0", path = "../rtic-common" }
 portable-atomic = { version = "1", default-features = false }
+embedded-hal = { version = "1.0.0-rc.1", optional = true }
+embedded-hal-async = { version = "1.0.0-rc.1", optional = true }
+embedded-hal-bus = { version = "0.1.0-rc.1", optional = true, features = ["async"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time"] }
@@ -29,3 +32,4 @@ tokio = { version = "1", features = ["rt", "macros", "time"] }
 [features]
 default = []
 testing = ["critical-section/std", "rtic-common/testing"]
+unstable = ["embedded-hal", "embedded-hal-async", "embedded-hal-bus"]

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -89,6 +89,7 @@ impl Package {
                     .chain(std::iter::once(None))
                     .collect()
             }
+            Package::RticSync => vec![Some("unstable".to_string()), None],
             _ => vec![None],
         }
     }


### PR DESCRIPTION
The pre-release embedded-hal-async 1.0.0-rc.1 has two traits for SPI: [`SpiBus`], which is typically implemented by HALs and [`SpiDevice`], which is implemented by pairing a chip select GPIO with a sharing mechanism. [`embedded-hal-bus`](https://docs.rs/embedded-hal-bus/0.1.0-rc.1/embedded_hal_bus/) provides implementations for some synchronization mechanisms.

Implement `SpiDevice` using `rtic_sync::arbiter::Arbiter`.

[`SpiBus`]: https://docs.rs/embedded-hal-async/1.0.0-rc.1/embedded_hal_async/spi/trait.SpiBus.html
[`SpiDevice`]: https://docs.rs/embedded-hal-async/1.0.0-rc.1/embedded_hal_async/spi/trait.SpiDevice.html