### PR TITLE
CI: rtic-monotonics: systick not always in scope

### DIFF
--- a/rtic-monotonics/src/lib.rs
+++ b/rtic-monotonics/src/lib.rs
@@ -4,7 +4,7 @@
 //! To enable the implementations, you must enable a feature for the specific MCU you're targeting.
 //!
 //! # Cortex-M Systick
-//! The [`systick`] monotonic works on all cortex-M parts, and requires that the feature `cortex-m-systick` is enabled.
+//! The `systick` monotonic works on all cortex-M parts, and requires that the feature `cortex-m-systick` is enabled.
 //!
 //! # RP2040
 //! The RP2040 monotonics require that the `rp2040` feature is enabled.


### PR DESCRIPTION
Links are checked during compilation, and to not
make it overly complex remove the link

```
error: unresolved link to `systick`
 --> rtic-monotonics/src/lib.rs:7:11
  |
7 | //! The [`systick`] monotonic works on all cortex-M parts, and requires that the feature `cortex-m-systick` is enabled.
  |           ^^^^^^^ no item named `systick` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`

error: could not document `rtic-monotonics`
```
