### PR TITLE
rtic-time does not need nightly

### DIFF
--- a/rtic-time/rust-toolchain.toml
+++ b/rtic-time/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly"
-components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
-targets = [ "thumbv6m-none-eabi", "thumbv7m-none-eabi" ]


### PR DESCRIPTION
I noticed that rtic-time currently depends on a nightly toolchain because of it's `rust-toolchain.toml`. This is not necessary, because is compiles fine on stable.