### PR TITLE
rtic-sync: add Arbiter for I2C

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -10,6 +10,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 ### Added
 
 - `arbiter::spi::ArbiterDevice` for sharing SPI buses using `embedded-hal-async`
+- `arbiter::i2c::ArbiterDevice` for sharing I2C buses using `embedded-hal-async`
 
 ### Changed
 


### PR DESCRIPTION
Adds `Arbiter` for I2C to easily share I2C bus with many I2C sensor drivers.
Usage example is also added to rustdoc.