### PR TITLE
Fix mono delay

### DIFF
--- a/examples/teensy4_blinky/Cargo.lock
+++ b/examples/teensy4_blinky/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "rtic-monotonics"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
+### Changed
+
+- Update to new `Monotonic` version
+
 ## v1.3.0 - 2023-11-08
 
 ### Added

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -10,6 +10,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Changed
 
 - Update to new `Monotonic` version
+### Fixed
+- **Soundness fix:** Monotonics did not wait long enough in `Duration` based delays.
 
 ## v1.3.0 - 2023-11-08
 

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -7,10 +7,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
-### Changed
-
-- Update to new `Monotonic` version
 ### Fixed
+
 - **Soundness fix:** Monotonics did not wait long enough in `Duration` based delays.
 
 ## v1.3.0 - 2023-11-08

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -3,6 +3,7 @@ name = "rtic-monotonics"
 version = "1.3.0"
 
 edition = "2021"
+rust-version = "1.75"
 authors = [
     "The Real-Time Interrupt-driven Concurrency developers",
     "Emil Fresk <emil.fresk@gmail.com>",

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -28,8 +28,8 @@ rustdoc-flags = ["--cfg", "docsrs"]
 
 [dependencies]
 rtic-time = { version = "1.0.0", path = "../rtic-time" }
-embedded-hal = { version = "1.0.0-rc.1" }
-embedded-hal-async = { version = "1.0.0-rc.1", optional = true }
+embedded-hal = { version = "1.0.0-rc.2" }
+embedded-hal-async = { version = "1.0.0-rc.2", optional = true }
 fugit = { version = "0.3.6" }
 atomic-polyfill = "1"
 cfg-if = "1.0.0"

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -3,7 +3,6 @@ name = "rtic-monotonics"
 version = "1.3.0"
 
 edition = "2021"
-rust-version = "1.75"
 authors = [
     "The Real-Time Interrupt-driven Concurrency developers",
     "Emil Fresk <emil.fresk@gmail.com>",

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -231,7 +231,11 @@ macro_rules! make_timer {
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+            fn delay_ms(&mut self, ms: u32) {
+                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -241,6 +241,7 @@ macro_rules! make_timer {
             type Duration = fugit::TimerDurationU64<TIMER_HZ>;
 
             const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+            const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
 
             fn now() -> Self::Instant {
                 let gpt = unsafe{ $timer::instance() };

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -29,7 +29,7 @@
 //! }
 //! ```
 
-use crate::{Monotonic, TimeoutError, TimerQueue};
+use crate::{Monotonic, TimerQueue};
 use atomic_polyfill::{compiler_fence, AtomicU32, Ordering};
 pub use fugit::{self, ExtU64, ExtU64Ceil};
 
@@ -179,65 +179,6 @@ macro_rules! make_timer {
                     cortex_m::peripheral::NVIC::unmask(ral::Interrupt::$timer);
                 }
             }
-
-            /// Used to access the underlying timer queue
-            #[doc(hidden)]
-            pub fn __tq() -> &'static TimerQueue<$mono_name> {
-                &$tq
-            }
-
-            /// Delay for some duration of time.
-            #[inline]
-            pub async fn delay(duration: <Self as Monotonic>::Duration) {
-                $tq.delay(duration).await;
-            }
-
-            /// Timeout at a specific time.
-            pub async fn timeout_at<F: core::future::Future>(
-                instant: <Self as rtic_time::Monotonic>::Instant,
-                future: F,
-            ) -> Result<F::Output, TimeoutError> {
-                $tq.timeout_at(instant, future).await
-            }
-
-            /// Timeout after a specific duration.
-            #[inline]
-            pub async fn timeout_after<F: core::future::Future>(
-                duration: <Self as Monotonic>::Duration,
-                future: F,
-            ) -> Result<F::Output, TimeoutError> {
-                $tq.timeout_after(duration, future).await
-            }
-
-            /// Delay to some specific time instant.
-            #[inline]
-            pub async fn delay_until(instant: <Self as Monotonic>::Instant) {
-                $tq.delay_until(instant).await;
-            }
-        }
-
-        #[cfg(feature = "embedded-hal-async")]
-        impl embedded_hal_async::delay::DelayUs for $mono_name {
-            #[inline]
-            async fn delay_us(&mut self, us: u32) {
-                Self::delay(u64::from(us).micros_at_least()).await;
-            }
-
-            #[inline]
-            async fn delay_ms(&mut self, ms: u32) {
-                Self::delay(u64::from(ms).millis_at_least()).await;
-            }
-        }
-
-        impl embedded_hal::delay::DelayUs for $mono_name {
-            fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
-                while Self::now() < done {}
-            }
-            fn delay_ms(&mut self, ms: u32) {
-                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
-                while Self::now() < done {}
-            }
         }
 
         impl Monotonic for $mono_name {
@@ -296,7 +237,13 @@ macro_rules! make_timer {
                     ral::write_reg!(ral::gpt, gpt, SR, OF1: 1);
                 }
             }
+
+            fn __tq() -> &'static TimerQueue<Self> {
+                &$tq
+            }
         }
+
+        rtic_time::embedded_hal_delay_impl_fugit64!($mono_name);
     };
 }
 

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -31,7 +31,7 @@
 
 use crate::{Monotonic, TimeoutError, TimerQueue};
 use atomic_polyfill::{compiler_fence, AtomicU32, Ordering};
-pub use fugit::{self, ExtU64};
+pub use fugit::{self, ExtU64, ExtU64Ceil};
 
 use imxrt_ral as ral;
 
@@ -220,18 +220,18 @@ macro_rules! make_timer {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-                Self::delay((us as u64).micros()).await;
+                Self::delay((us as u64).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis()).await;
+                Self::delay((ms as u64).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + (us as u64).micros();
+                let done = Self::now() + (us as u64).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -244,6 +244,9 @@ macro_rules! make_timer {
         }
 
         rtic_time::embedded_hal_delay_impl_fugit64!($mono_name);
+
+        #[cfg(feature = "embedded-hal-async")]
+        rtic_time::embedded_hal_async_delay_impl_fugit64!($mono_name);
     };
 }
 

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -220,18 +220,18 @@ macro_rules! make_timer {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-                Self::delay((us as u64).micros_at_least()).await;
+                Self::delay(u64::from(us).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis_at_least()).await;
+                Self::delay(u64::from(ms).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + (us as u64).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/nrf/rtc.rs
+++ b/rtic-monotonics/src/nrf/rtc.rs
@@ -124,72 +124,18 @@ macro_rules! make_rtc {
                 }
             }
 
-            /// Used to access the underlying timer queue
-            #[doc(hidden)]
-            pub fn __tq() -> &'static TimerQueue<$mono_name> {
-                &$tq
-            }
-
             #[inline(always)]
             fn is_overflow() -> bool {
                 let rtc = unsafe { &*$rtc::PTR };
                 rtc.events_ovrflw.read().bits() == 1
             }
-
-            /// Timeout at a specific time.
-            #[inline]
-            pub async fn timeout_at<F: Future>(
-                instant: <Self as Monotonic>::Instant,
-                future: F,
-            ) -> Result<F::Output, TimeoutError> {
-                $tq.timeout_at(instant, future).await
-            }
-
-            /// Timeout after a specific duration.
-            #[inline]
-            pub async fn timeout_after<F: Future>(
-                duration: <Self as Monotonic>::Duration,
-                future: F,
-            ) -> Result<F::Output, TimeoutError> {
-                $tq.timeout_after(duration, future).await
-            }
-
-            /// Delay for some duration of time.
-            #[inline]
-            pub async fn delay(duration: <Self as Monotonic>::Duration) {
-                $tq.delay(duration).await;
-            }
-
-            /// Delay to some specific time instant.
-            #[inline]
-            pub async fn delay_until(instant: <Self as Monotonic>::Instant) {
-                $tq.delay_until(instant).await;
-            }
         }
+
+
+        rtic_time::embedded_hal_delay_impl_fugit64!($mono_name);
 
         #[cfg(feature = "embedded-hal-async")]
-        impl embedded_hal_async::delay::DelayUs for $mono_name {
-            #[inline]
-            async fn delay_us(&mut self, us: u32) {
-               Self::delay(u64::from(us).micros_at_least()).await;
-            }
-
-            #[inline]
-            async fn delay_ms(&mut self, ms: u32) {
-                Self::delay(u64::from(ms).millis_at_least()).await;
-            }
-        }
-
-        impl embedded_hal::delay::DelayUs for $mono_name {
-            fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
-                while Self::now() < done {}
-            }
-            fn delay_ms(&mut self, ms: u32) {
-                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
-                while Self::now() < done {}
-            }
-        }
+        rtic_time::embedded_hal_async_delay_impl_fugit64!($mono_name);
 
         impl Monotonic for $mono_name {
             const ZERO: Self::Instant = Self::Instant::from_ticks(0);
@@ -249,6 +195,10 @@ macro_rules! make_rtc {
 
             fn pend_interrupt() {
                 pac::NVIC::pend(Interrupt::$rtc);
+            }
+
+            fn __tq() -> &'static TimerQueue<$mono_name> {
+                &$tq
             }
         }
     };

--- a/rtic-monotonics/src/nrf/rtc.rs
+++ b/rtic-monotonics/src/nrf/rtc.rs
@@ -43,7 +43,7 @@ use nrf9160_pac::{self as pac, Interrupt, RTC0_NS as RTC0, RTC1_NS as RTC1};
 use crate::{Monotonic, TimeoutError, TimerQueue};
 use atomic_polyfill::{AtomicU32, Ordering};
 use core::future::Future;
-pub use fugit::{self, ExtU64};
+pub use fugit::{self, ExtU64, ExtU64Ceil};
 
 #[doc(hidden)]
 #[macro_export]
@@ -171,18 +171,18 @@ macro_rules! make_rtc {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-               Self::delay((us as u64).micros()).await;
+               Self::delay((us as u64).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis()).await;
+                Self::delay((ms as u64).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros();
+                let done = Self::now() + u64::from(us).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/nrf/rtc.rs
+++ b/rtic-monotonics/src/nrf/rtc.rs
@@ -171,12 +171,12 @@ macro_rules! make_rtc {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-               Self::delay((us as u64).micros_at_least()).await;
+               Self::delay(u64::from(us).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis_at_least()).await;
+                Self::delay(u64::from(ms).millis_at_least()).await;
             }
         }
 

--- a/rtic-monotonics/src/nrf/rtc.rs
+++ b/rtic-monotonics/src/nrf/rtc.rs
@@ -189,6 +189,7 @@ macro_rules! make_rtc {
 
         impl Monotonic for $mono_name {
             const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+            const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
 
             type Instant = fugit::TimerInstantU64<32_768>;
             type Duration = fugit::TimerDurationU64<32_768>;

--- a/rtic-monotonics/src/nrf/rtc.rs
+++ b/rtic-monotonics/src/nrf/rtc.rs
@@ -182,7 +182,11 @@ macro_rules! make_rtc {
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+            fn delay_ms(&mut self, ms: u32) {
+                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -29,7 +29,7 @@
 use crate::{Monotonic, TimeoutError, TimerQueue};
 use atomic_polyfill::{AtomicU32, Ordering};
 use core::future::Future;
-pub use fugit::{self, ExtU64};
+pub use fugit::{self, ExtU64, ExtU64Ceil};
 
 #[cfg(feature = "nrf52810")]
 use nrf52810_pac::{self as pac, Interrupt, TIMER0, TIMER1, TIMER2};
@@ -207,18 +207,18 @@ macro_rules! make_timer {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-                Self::delay((us as u64).micros()).await;
+                Self::delay((us as u64).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis()).await;
+                Self::delay((ms as u64).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + (us as u64).micros();
+                let done = Self::now() + (us as u64).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -160,72 +160,17 @@ macro_rules! make_timer {
                 }
             }
 
-            /// Used to access the underlying timer queue
-            #[doc(hidden)]
-            pub fn __tq() -> &'static TimerQueue<$mono_name> {
-                &$tq
-            }
-
             #[inline(always)]
             fn is_overflow() -> bool {
                 let timer = unsafe { &*$timer::PTR };
                 timer.events_compare[1].read().bits() & 1 != 0
             }
-
-            /// Timeout at a specific time.
-            #[inline]
-            pub async fn timeout_at<F: Future>(
-                instant: <Self as Monotonic>::Instant,
-                future: F,
-            ) -> Result<F::Output, TimeoutError> {
-                $tq.timeout_at(instant, future).await
-            }
-
-            /// Timeout after a specific duration.
-            #[inline]
-            pub async fn timeout_after<F: Future>(
-                duration: <Self as Monotonic>::Duration,
-                future: F,
-            ) -> Result<F::Output, TimeoutError> {
-                $tq.timeout_after(duration, future).await
-            }
-
-            /// Delay for some duration of time.
-            #[inline]
-            pub async fn delay(duration: <Self as Monotonic>::Duration) {
-                $tq.delay(duration).await;
-            }
-
-            /// Delay to some specific time instant.
-            #[inline]
-            pub async fn delay_until(instant: <Self as Monotonic>::Instant) {
-                $tq.delay_until(instant).await;
-            }
         }
+
+        rtic_time::embedded_hal_delay_impl_fugit64!($mono_name);
 
         #[cfg(feature = "embedded-hal-async")]
-        impl embedded_hal_async::delay::DelayUs for $mono_name {
-            #[inline]
-            async fn delay_us(&mut self, us: u32) {
-                Self::delay(u64::from(us).micros_at_least()).await;
-            }
-
-            #[inline]
-            async fn delay_ms(&mut self, ms: u32) {
-                Self::delay(u64::from(ms).millis_at_least()).await;
-            }
-        }
-
-        impl embedded_hal::delay::DelayUs for $mono_name {
-            fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
-                while Self::now() < done {}
-            }
-            fn delay_ms(&mut self, ms: u32) {
-                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
-                while Self::now() < done {}
-            }
-        }
+        rtic_time::embedded_hal_async_delay_impl_fugit64!($mono_name);
 
         impl Monotonic for $mono_name {
             const ZERO: Self::Instant = Self::Instant::from_ticks(0);
@@ -286,6 +231,10 @@ macro_rules! make_timer {
 
             fn pend_interrupt() {
                 pac::NVIC::pend(Interrupt::$timer);
+            }
+
+            fn __tq() -> &'static TimerQueue<$mono_name> {
+                &$tq
             }
         }
     };

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -207,18 +207,18 @@ macro_rules! make_timer {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-                Self::delay((us as u64).micros_at_least()).await;
+                Self::delay(u64::from(us).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis_at_least()).await;
+                Self::delay(u64::from(ms).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + (us as u64).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -225,6 +225,7 @@ macro_rules! make_timer {
 
         impl Monotonic for $mono_name {
             const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+            const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
 
             type Instant = fugit::TimerInstantU64<1_000_000>;
             type Duration = fugit::TimerDurationU64<1_000_000>;

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -218,7 +218,11 @@ macro_rules! make_timer {
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+            fn delay_ms(&mut self, ms: u32) {
+                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -160,10 +160,46 @@ macro_rules! make_timer {
                 }
             }
 
+            /// Used to access the underlying timer queue
+            #[doc(hidden)]
+            pub fn __tq() -> &'static TimerQueue<$mono_name> {
+                &$tq
+            }
+
             #[inline(always)]
             fn is_overflow() -> bool {
                 let timer = unsafe { &*$timer::PTR };
                 timer.events_compare[1].read().bits() & 1 != 0
+            }
+
+            /// Timeout at a specific time.
+            #[inline]
+            pub async fn timeout_at<F: Future>(
+                instant: <Self as Monotonic>::Instant,
+                future: F,
+            ) -> Result<F::Output, TimeoutError> {
+                $tq.timeout_at(instant, future).await
+            }
+
+            /// Timeout after a specific duration.
+            #[inline]
+            pub async fn timeout_after<F: Future>(
+                duration: <Self as Monotonic>::Duration,
+                future: F,
+            ) -> Result<F::Output, TimeoutError> {
+                $tq.timeout_after(duration, future).await
+            }
+
+            /// Delay for some duration of time.
+            #[inline]
+            pub async fn delay(duration: <Self as Monotonic>::Duration) {
+                $tq.delay(duration).await;
+            }
+
+            /// Delay to some specific time instant.
+            #[inline]
+            pub async fn delay_until(instant: <Self as Monotonic>::Instant) {
+                $tq.delay_until(instant).await;
             }
         }
 
@@ -231,10 +267,6 @@ macro_rules! make_timer {
 
             fn pend_interrupt() {
                 pac::NVIC::pend(Interrupt::$timer);
-            }
-
-            fn __tq() -> &'static TimerQueue<$mono_name> {
-                &$tq
             }
         }
     };

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -104,6 +104,7 @@ impl Monotonic for Timer {
     type Duration = fugit::TimerDurationU64<1_000_000>;
 
     const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+    const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
 
     fn now() -> Self::Instant {
         let timer = Self::timer();

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -155,11 +155,11 @@ impl Monotonic for Timer {
 #[cfg(feature = "embedded-hal-async")]
 impl embedded_hal_async::delay::DelayUs for Timer {
     async fn delay_us(&mut self, us: u32) {
-        Self::delay((us as u64).micros_at_least()).await;
+        Self::delay(u64::from(us).micros_at_least()).await;
     }
 
     async fn delay_ms(&mut self, ms: u32) {
-        Self::delay((ms as u64).millis_at_least()).await;
+        Self::delay(u64::from(ms).millis_at_least()).await;
     }
 }
 

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -28,7 +28,7 @@ use super::Monotonic;
 
 pub use super::{TimeoutError, TimerQueue};
 use core::future::Future;
-pub use fugit::{self, ExtU64};
+pub use fugit::{self, ExtU64, ExtU64Ceil};
 use rp2040_pac::{timer, Interrupt, NVIC, RESETS, TIMER};
 
 /// Timer implementing [`Monotonic`] which runs at 1 MHz.
@@ -155,17 +155,17 @@ impl Monotonic for Timer {
 #[cfg(feature = "embedded-hal-async")]
 impl embedded_hal_async::delay::DelayUs for Timer {
     async fn delay_us(&mut self, us: u32) {
-        Self::delay((us as u64).micros()).await;
+        Self::delay((us as u64).micros_at_least()).await;
     }
 
     async fn delay_ms(&mut self, ms: u32) {
-        Self::delay((ms as u64).millis()).await;
+        Self::delay((ms as u64).millis_at_least()).await;
     }
 }
 
 impl embedded_hal::delay::DelayUs for Timer {
     fn delay_us(&mut self, us: u32) {
-        let done = Self::now() + u64::from(us).micros();
+        let done = Self::now() + u64::from(us).micros_at_least();
         while Self::now() < done {}
     }
 }

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -165,7 +165,11 @@ impl embedded_hal_async::delay::DelayUs for Timer {
 
 impl embedded_hal::delay::DelayUs for Timer {
     fn delay_us(&mut self, us: u32) {
-        let done = Self::now() + u64::from(us).micros_at_least();
+        let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
+        while Self::now() < done {}
+    }
+    fn delay_ms(&mut self, ms: u32) {
+        let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
         while Self::now() < done {}
     }
 }

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -60,45 +60,6 @@ impl Timer {
 
 static TIMER_QUEUE: TimerQueue<Timer> = TimerQueue::new();
 
-// Forward timerqueue interface
-impl Timer {
-    /// Used to access the underlying timer queue
-    #[doc(hidden)]
-    pub fn __tq() -> &'static TimerQueue<Timer> {
-        &TIMER_QUEUE
-    }
-
-    /// Timeout at a specific time.
-    #[inline]
-    pub async fn timeout_at<F: Future>(
-        instant: <Self as Monotonic>::Instant,
-        future: F,
-    ) -> Result<F::Output, TimeoutError> {
-        TIMER_QUEUE.timeout_at(instant, future).await
-    }
-
-    /// Timeout after a specific duration.
-    #[inline]
-    pub async fn timeout_after<F: Future>(
-        duration: <Self as Monotonic>::Duration,
-        future: F,
-    ) -> Result<F::Output, TimeoutError> {
-        TIMER_QUEUE.timeout_after(duration, future).await
-    }
-
-    /// Delay for some duration of time.
-    #[inline]
-    pub async fn delay(duration: <Self as Monotonic>::Duration) {
-        TIMER_QUEUE.delay(duration).await;
-    }
-
-    /// Delay to some specific time instant.
-    #[inline]
-    pub async fn delay_until(instant: <Self as Monotonic>::Instant) {
-        TIMER_QUEUE.delay_until(instant).await;
-    }
-}
-
 impl Monotonic for Timer {
     type Instant = fugit::TimerInstantU64<1_000_000>;
     type Duration = fugit::TimerDurationU64<1_000_000>;
@@ -150,29 +111,16 @@ impl Monotonic for Timer {
     fn enable_timer() {}
 
     fn disable_timer() {}
+
+    fn __tq() -> &'static TimerQueue<Timer> {
+        &TIMER_QUEUE
+    }
 }
+
+rtic_time::embedded_hal_delay_impl_fugit64!(Timer);
 
 #[cfg(feature = "embedded-hal-async")]
-impl embedded_hal_async::delay::DelayUs for Timer {
-    async fn delay_us(&mut self, us: u32) {
-        Self::delay(u64::from(us).micros_at_least()).await;
-    }
-
-    async fn delay_ms(&mut self, ms: u32) {
-        Self::delay(u64::from(ms).millis_at_least()).await;
-    }
-}
-
-impl embedded_hal::delay::DelayUs for Timer {
-    fn delay_us(&mut self, us: u32) {
-        let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
-        while Self::now() < done {}
-    }
-    fn delay_ms(&mut self, ms: u32) {
-        let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
-        while Self::now() < done {}
-    }
-}
+rtic_time::embedded_hal_async_delay_impl_fugit64!(Timer);
 
 /// Register the Timer interrupt for the monotonic.
 #[macro_export]

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -222,18 +222,18 @@ macro_rules! make_timer {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-                Self::delay((us as u64).micros_at_least()).await;
+                Self::delay(u64::from(us).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis_at_least()).await;
+                Self::delay(u64::from(ms).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + (us as u64).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -233,7 +233,11 @@ macro_rules! make_timer {
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + u64::from(us).micros_at_least();
+                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+            fn delay_ms(&mut self, ms: u32) {
+                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -243,6 +243,7 @@ macro_rules! make_timer {
             type Duration = fugit::TimerDurationU64<TIMER_HZ>;
 
             const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+            const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
 
             fn now() -> Self::Instant {
                 // Credits to the `time-driver` of `embassy-stm32`.

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -36,7 +36,7 @@
 
 use crate::{Monotonic, TimeoutError, TimerQueue};
 use atomic_polyfill::{compiler_fence, AtomicU64, Ordering};
-pub use fugit::{self, ExtU64};
+pub use fugit::{self, ExtU64, ExtU64Ceil};
 use stm32_metapac as pac;
 
 mod _generated {
@@ -222,18 +222,18 @@ macro_rules! make_timer {
         impl embedded_hal_async::delay::DelayUs for $mono_name {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
-                Self::delay((us as u64).micros()).await;
+                Self::delay((us as u64).micros_at_least()).await;
             }
 
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
-                Self::delay((ms as u64).millis()).await;
+                Self::delay((ms as u64).millis_at_least()).await;
             }
         }
 
         impl embedded_hal::delay::DelayUs for $mono_name {
             fn delay_us(&mut self, us: u32) {
-                let done = Self::now() + (us as u64).micros();
+                let done = Self::now() + (us as u64).micros_at_least();
                 while Self::now() < done {}
             }
         }

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -160,8 +160,14 @@ impl Monotonic for Systick {
 cfg_if::cfg_if! {
     if #[cfg(feature = "systick-64bit")] {
         rtic_time::embedded_hal_delay_impl_fugit64!(Systick);
+
+        #[cfg(feature = "embedded-hal-async")]
+        rtic_time::embedded_hal_async_delay_impl_fugit64!(Systick);
     } else {
-        rtic_time::embedded_hal_delay_impl_fugit32!(Systick);
+        rtic_time::embedded_hal_delay_impl_fugit64!(Systick);
+
+        #[cfg(feature = "embedded-hal-async")]
+        rtic_time::embedded_hal_async_delay_impl_fugit64!(Systick);
     }
 }
 

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -164,10 +164,10 @@ cfg_if::cfg_if! {
         #[cfg(feature = "embedded-hal-async")]
         rtic_time::embedded_hal_async_delay_impl_fugit64!(Systick);
     } else {
-        rtic_time::embedded_hal_delay_impl_fugit64!(Systick);
+        rtic_time::embedded_hal_delay_impl_fugit32!(Systick);
 
         #[cfg(feature = "embedded-hal-async")]
-        rtic_time::embedded_hal_async_delay_impl_fugit64!(Systick);
+        rtic_time::embedded_hal_async_delay_impl_fugit32!(Systick);
     }
 }
 

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -40,11 +40,11 @@ use cortex_m::peripheral::SYST;
 pub use fugit;
 cfg_if::cfg_if! {
     if #[cfg(feature = "systick-64bit")] {
-        pub use fugit::ExtU64;
+        pub use fugit::{ExtU64, ExtU64Ceil};
         use atomic_polyfill::AtomicU64;
         static SYSTICK_CNT: AtomicU64 = AtomicU64::new(0);
     } else {
-        pub use fugit::ExtU32;
+        pub use fugit::{ExtU32, ExtU32Ceil};
         use atomic_polyfill::AtomicU32;
         static SYSTICK_CNT: AtomicU32 = AtomicU32::new(0);
     }
@@ -194,13 +194,13 @@ impl embedded_hal_async::delay::DelayUs for Systick {
     async fn delay_us(&mut self, us: u32) {
         #[cfg(feature = "systick-64bit")]
         let us = u64::from(us);
-        Self::delay(us.micros()).await;
+        Self::delay(us.micros_at_least()).await;
     }
 
     async fn delay_ms(&mut self, ms: u32) {
         #[cfg(feature = "systick-64bit")]
         let ms = u64::from(ms);
-        Self::delay(ms.millis()).await;
+        Self::delay(ms.millis_at_least()).await;
     }
 }
 
@@ -208,7 +208,7 @@ impl embedded_hal::delay::DelayUs for Systick {
     fn delay_us(&mut self, us: u32) {
         #[cfg(feature = "systick-64bit")]
         let us = u64::from(us);
-        let done = Self::now() + us.micros();
+        let done = Self::now() + us.micros_at_least();
         while Self::now() < done {}
     }
 }

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -156,6 +156,7 @@ impl Monotonic for Systick {
     }
 
     const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+    const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
 
     fn now() -> Self::Instant {
         if Self::systick().has_wrapped() {

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -208,7 +208,13 @@ impl embedded_hal::delay::DelayUs for Systick {
     fn delay_us(&mut self, us: u32) {
         #[cfg(feature = "systick-64bit")]
         let us = u64::from(us);
-        let done = Self::now() + us.micros_at_least();
+        let done = Self::now() + us.micros_at_least() + Self::TICK_PERIOD;
+        while Self::now() < done {}
+    }
+    fn delay_ms(&mut self, ms: u32) {
+        #[cfg(feature = "systick-64bit")]
+        let ms = u64::from(ms);
+        let done = Self::now() + ms.millis_at_least() + Self::TICK_PERIOD;
         while Self::now() < done {}
     }
 }

--- a/rtic-sync/Cargo.toml
+++ b/rtic-sync/Cargo.toml
@@ -21,9 +21,9 @@ heapless = "0.7"
 critical-section = "1"
 rtic-common = { version = "1.0.0", path = "../rtic-common" }
 portable-atomic = { version = "1", default-features = false }
-embedded-hal = { version = "1.0.0-rc.1", optional = true }
-embedded-hal-async = { version = "1.0.0-rc.1", optional = true }
-embedded-hal-bus = { version = "0.1.0-rc.1", optional = true, features = ["async"] }
+embedded-hal = { version = "1.0.0-rc.2", optional = true }
+embedded-hal-async = { version = "1.0.0-rc.2", optional = true }
+embedded-hal-bus = { version = "0.1.0-rc.2", optional = true, features = ["async"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time"] }

--- a/rtic-sync/src/arbiter.rs
+++ b/rtic-sync/src/arbiter.rs
@@ -197,7 +197,7 @@ pub mod spi {
     use super::Arbiter;
     use embedded_hal::digital::OutputPin;
     use embedded_hal_async::{
-        delay::DelayUs,
+        delay::DelayNs,
         spi::{ErrorType, Operation, SpiBus, SpiDevice},
     };
     use embedded_hal_bus::spi::DeviceError;
@@ -229,7 +229,7 @@ pub mod spi {
         Word: Copy + 'static,
         BUS: SpiBus<Word>,
         CS: OutputPin,
-        D: DelayUs,
+        D: DelayNs,
     {
         async fn transaction(
             &mut self,
@@ -246,10 +246,10 @@ pub mod spi {
                         Operation::Write(buf) => bus.write(buf).await,
                         Operation::Transfer(read, write) => bus.transfer(read, write).await,
                         Operation::TransferInPlace(buf) => bus.transfer_in_place(buf).await,
-                        Operation::DelayUs(us) => match bus.flush().await {
+                        Operation::DelayNs(ns) => match bus.flush().await {
                             Err(e) => Err(e),
                             Ok(()) => {
-                                self.delay.delay_us(*us).await;
+                                self.delay.delay_ns(*ns).await;
                                 Ok(())
                             }
                         },

--- a/rtic-time/CHANGELOG.md
+++ b/rtic-time/CHANGELOG.md
@@ -16,5 +16,6 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Fixed
 
 - If the queue was non-empty and a new instant was added that was earlier than `head`, then the queue would no pend the monotonic handler. This would cause the new `head` to be dequeued at the wrong time.
+- `TimerQueue` did not wait long enough in `Duration` based delays
 
 ## [v1.0.0] - 2023-05-31

--- a/rtic-time/CHANGELOG.md
+++ b/rtic-time/CHANGELOG.md
@@ -15,7 +15,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- **Soundness fix:** `TimerQueue` did not wait long enough in `Duration` based delays. Fixing this sadly required adding a `const TICK_PERIOD` to the `Monotonic` trait, which requires updating all existing implementations.
 - If the queue was non-empty and a new instant was added that was earlier than `head`, then the queue would no pend the monotonic handler. This would cause the new `head` to be dequeued at the wrong time.
-- `TimerQueue` did not wait long enough in `Duration` based delays
 
 ## [v1.0.0] - 2023-05-31

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -3,6 +3,7 @@ name = "rtic-time"
 version = "1.0.0"
 
 edition = "2021"
+rust-version = "1.75"
 authors = [
     "The Real-Time Interrupt-driven Concurrency developers",
     "Emil Fresk <emil.fresk@gmail.com>",

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -22,8 +22,8 @@ futures-util = { version = "0.3.25", default-features = false }
 rtic-common = { version = "1.0.0", path = "../rtic-common" }
 
 [dev-dependencies]
-embedded-hal = { version = "1.0.0-rc.1" }
-embedded-hal-async = { version = "1.0.0-rc.1" }
+embedded-hal = { version = "1.0.0-rc.2" }
+embedded-hal-async = { version = "1.0.0-rc.2" }
 fugit = "0.3.7"
 parking_lot = "0.12"
 cassette = "0.2"

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -4,11 +4,11 @@ version = "1.0.0"
 
 edition = "2021"
 authors = [
-  "The Real-Time Interrupt-driven Concurrency developers",
-  "Emil Fresk <emil.fresk@gmail.com>",
-  "Henrik Tjäder <henrik@tjaders.com>",
-  "Jorge Aparicio <jorge@japaric.io>",
-  "Per Lindgren <per.lindgren@ltu.se>",
+    "The Real-Time Interrupt-driven Concurrency developers",
+    "Emil Fresk <emil.fresk@gmail.com>",
+    "Henrik Tjäder <henrik@tjaders.com>",
+    "Jorge Aparicio <jorge@japaric.io>",
+    "Per Lindgren <per.lindgren@ltu.se>",
 ]
 categories = ["concurrency", "embedded", "no-std", "asynchronous"]
 description = "rtic-time lib TODO"
@@ -22,5 +22,9 @@ futures-util = { version = "0.3.25", default-features = false }
 rtic-common = { version = "1.0.0", path = "../rtic-common" }
 
 [dev-dependencies]
+embedded-hal = { version = "1.0.0-rc.1" }
+embedded-hal-async = { version = "1.0.0-rc.1" }
+fugit = "0.3.7"
 parking_lot = "0.12"
 cassette = "0.2"
+cooked-waker = "5.0.0"

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -3,7 +3,6 @@ name = "rtic-time"
 version = "1.0.0"
 
 edition = "2021"
-rust-version = "1.75"
 authors = [
     "The Real-Time Interrupt-driven Concurrency developers",
     "Emil Fresk <emil.fresk@gmail.com>",

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -4,11 +4,11 @@ version = "1.0.0"
 
 edition = "2021"
 authors = [
-    "The Real-Time Interrupt-driven Concurrency developers",
-    "Emil Fresk <emil.fresk@gmail.com>",
-    "Henrik Tjäder <henrik@tjaders.com>",
-    "Jorge Aparicio <jorge@japaric.io>",
-    "Per Lindgren <per.lindgren@ltu.se>",
+  "The Real-Time Interrupt-driven Concurrency developers",
+  "Emil Fresk <emil.fresk@gmail.com>",
+  "Henrik Tjäder <henrik@tjaders.com>",
+  "Jorge Aparicio <jorge@japaric.io>",
+  "Per Lindgren <per.lindgren@ltu.se>",
 ]
 categories = ["concurrency", "embedded", "no-std", "asynchronous"]
 description = "rtic-time lib TODO"

--- a/rtic-time/src/lib.rs
+++ b/rtic-time/src/lib.rs
@@ -23,7 +23,7 @@ mod linked_list;
 mod monotonic;
 
 /// Holds a waker and at which time instant this waker shall be awoken.
-struct WaitingWaker<Mono: Monotonic + ?Sized> {
+struct WaitingWaker<Mono: Monotonic> {
     waker: Waker,
     release_at: Mono::Instant,
     was_popped: AtomicBool,
@@ -66,7 +66,7 @@ impl<Mono: Monotonic> PartialOrd for WaitingWaker<Mono> {
 /// complete.
 ///
 /// Do not call `mem::forget` on an awaited future, or there will be dragons!
-pub struct TimerQueue<Mono: Monotonic + ?Sized> {
+pub struct TimerQueue<Mono: Monotonic> {
     queue: LinkedList<WaitingWaker<Mono>>,
     initialized: AtomicBool,
 }

--- a/rtic-time/src/lib.rs
+++ b/rtic-time/src/lib.rs
@@ -188,20 +188,29 @@ impl<Mono: Monotonic> TimerQueue<Mono> {
         duration: Mono::Duration,
         future: F,
     ) -> Result<F::Output, TimeoutError> {
+        let now = Mono::now();
+        let mut timeout = now + duration;
+        if now != timeout {
+            timeout = timeout + Mono::TICK_PERIOD;
+        }
+
         // Wait for one period longer, because by definition timers have an uncertainty
         // of one period, so waiting for 'at least' needs to compensate for that.
-        self.timeout_at(Mono::now() + duration + Mono::TICK_PERIOD, future)
-            .await
+        self.timeout_at(timeout, future).await
     }
 
     /// Delay for at least some duration of time.
     #[inline]
     pub async fn delay(&self, duration: Mono::Duration) {
         let now = Mono::now();
+        let mut timeout = now + duration;
+        if now != timeout {
+            timeout = timeout + Mono::TICK_PERIOD;
+        }
 
         // Wait for one period longer, because by definition timers have an uncertainty
         // of one period, so waiting for 'at least' needs to compensate for that.
-        self.delay_until(now + duration + Mono::TICK_PERIOD).await;
+        self.delay_until(timeout).await;
     }
 
     /// Delay to some specific time instant.

--- a/rtic-time/src/lib.rs
+++ b/rtic-time/src/lib.rs
@@ -23,7 +23,7 @@ mod linked_list;
 mod monotonic;
 
 /// Holds a waker and at which time instant this waker shall be awoken.
-struct WaitingWaker<Mono: Monotonic> {
+struct WaitingWaker<Mono: Monotonic + ?Sized> {
     waker: Waker,
     release_at: Mono::Instant,
     was_popped: AtomicBool,
@@ -66,7 +66,7 @@ impl<Mono: Monotonic> PartialOrd for WaitingWaker<Mono> {
 /// complete.
 ///
 /// Do not call `mem::forget` on an awaited future, or there will be dragons!
-pub struct TimerQueue<Mono: Monotonic> {
+pub struct TimerQueue<Mono: Monotonic + ?Sized> {
     queue: LinkedList<WaitingWaker<Mono>>,
     initialized: AtomicBool,
 }

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -82,7 +82,7 @@ macro_rules! embedded_hal_delay_impl_fugit64 {
                 let mut done = now + u64::from(us).nanos_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + Self::TICK_PERIOD;
+                    done += Self::TICK_PERIOD;
                 }
 
                 while Self::now() < done {}
@@ -95,7 +95,7 @@ macro_rules! embedded_hal_delay_impl_fugit64 {
                 let mut done = now + u64::from(us).micros_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + Self::TICK_PERIOD;
+                    done += Self::TICK_PERIOD;
                 }
 
                 while Self::now() < done {}
@@ -108,7 +108,7 @@ macro_rules! embedded_hal_delay_impl_fugit64 {
                 let mut done = now + u64::from(ms).millis_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + Self::TICK_PERIOD;
+                    done += Self::TICK_PERIOD;
                 }
 
                 while Self::now() < done {}
@@ -157,7 +157,7 @@ macro_rules! embedded_hal_delay_impl_fugit32 {
                 let mut done = now + us.nanos_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + Self::TICK_PERIOD;
+                    done += Self::TICK_PERIOD;
                 }
 
                 while Self::now() < done {}
@@ -170,7 +170,7 @@ macro_rules! embedded_hal_delay_impl_fugit32 {
                 let mut done = now + us.micros_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + Self::TICK_PERIOD;
+                    done += Self::TICK_PERIOD;
                 }
 
                 while Self::now() < done {}
@@ -183,7 +183,7 @@ macro_rules! embedded_hal_delay_impl_fugit32 {
                 let mut done = now + ms.millis_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + Self::TICK_PERIOD;
+                    done += Self::TICK_PERIOD;
                 }
 
                 while Self::now() < done {}

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -1,12 +1,14 @@
 //! A monotonic clock / counter definition.
 
+use crate::{TimeoutError, TimerQueue};
+
 /// # A monotonic clock / counter definition.
 ///
 /// ## Correctness
 ///
 /// The trait enforces that proper time-math is implemented between `Instant` and `Duration`. This
 /// is a requirement on the time library that the user chooses to use.
-pub trait Monotonic {
+pub trait Monotonic: Sized + 'static {
     /// The time at time zero.
     const ZERO: Self::Instant;
 
@@ -67,4 +69,114 @@ pub trait Monotonic {
     ///
     /// NOTE: This may be called more than once.
     fn disable_timer() {}
+
+    /// Return a reference to the underlying timer queue
+    #[doc(hidden)]
+    fn __tq() -> &'static TimerQueue<Self>;
+
+    /// Delay for some duration of time.
+    #[inline]
+    fn delay(duration: <Self as Monotonic>::Duration) -> impl core::future::Future<Output = ()> {
+        async move {
+            Self::__tq().delay(duration).await;
+        }
+    }
+
+    /// Timeout at a specific time.
+    fn timeout_at<F: core::future::Future>(
+        instant: Self::Instant,
+        future: F,
+    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>> {
+        async move { Self::__tq().timeout_at(instant, future).await }
+    }
+
+    /// Timeout after a specific duration.
+    #[inline]
+    fn timeout_after<F: core::future::Future>(
+        duration: <Self as Monotonic>::Duration,
+        future: F,
+    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>> {
+        async move { Self::__tq().timeout_after(duration, future).await }
+    }
+
+    /// Delay to some specific time instant.
+    #[inline]
+    fn delay_until(
+        instant: <Self as Monotonic>::Instant,
+    ) -> impl core::future::Future<Output = ()> {
+        async move {
+            TimerQueue::<Self>::new();
+            Self::__tq().delay_until(instant).await;
+        }
+    }
+}
+
+/// Creates impl blocks for `embedded_hal::delay::DelayUs` and
+/// `embedded_hal_async::delay::DelayUs`, based on `fugit::ExtU64Ceil`.
+#[macro_export]
+macro_rules! embedded_hal_delay_impl_fugit64 {
+    ($t:ty) => {
+        #[cfg(feature = "embedded-hal-async")]
+        impl ::embedded_hal_async::delay::DelayUs for $t {
+            #[inline]
+            async fn delay_us(&mut self, us: u32) {
+                use ::fugit::ExtU64Ceil;
+                Self::delay(u64::from(us).micros_at_least()).await;
+            }
+
+            #[inline]
+            async fn delay_ms(&mut self, ms: u32) {
+                use ::fugit::ExtU64Ceil;
+                Self::delay(u64::from(ms).millis_at_least()).await;
+            }
+        }
+
+        impl ::embedded_hal::delay::DelayUs for $t {
+            fn delay_us(&mut self, us: u32) {
+                use ::fugit::ExtU64Ceil;
+                let done = Self::now() + u64::from(us).micros_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+            fn delay_ms(&mut self, ms: u32) {
+                use ::fugit::ExtU64Ceil;
+                let done = Self::now() + u64::from(ms).millis_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+        }
+    };
+}
+
+/// Creates impl blocks for `embedded_hal::delay::DelayUs` and
+/// `embedded_hal_async::delay::DelayUs`, based on `fugit::ExtU32Ceil`.
+#[macro_export]
+macro_rules! embedded_hal_delay_impl_fugit32 {
+    ($t:ty) => {
+        #[cfg(feature = "embedded-hal-async")]
+        impl ::embedded_hal_async::delay::DelayUs for $t {
+            #[inline]
+            async fn delay_us(&mut self, us: u32) {
+                use ::fugit::ExtU32Ceil;
+                Self::delay(us.micros_at_least()).await;
+            }
+
+            #[inline]
+            async fn delay_ms(&mut self, ms: u32) {
+                use ::fugit::ExtU32Ceil;
+                Self::delay(ms.millis_at_least()).await;
+            }
+        }
+
+        impl ::embedded_hal::delay::DelayUs for $t {
+            fn delay_us(&mut self, us: u32) {
+                use ::fugit::ExtU32Ceil;
+                let done = Self::now() + us.micros_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+            fn delay_ms(&mut self, ms: u32) {
+                use ::fugit::ExtU32Ceil;
+                let done = Self::now() + ms.millis_at_least() + Self::TICK_PERIOD;
+                while Self::now() < done {}
+            }
+        }
+    };
 }

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -74,7 +74,20 @@ pub trait Monotonic: Sized + 'static {
 #[macro_export]
 macro_rules! embedded_hal_delay_impl_fugit64 {
     ($t:ty) => {
-        impl ::embedded_hal::delay::DelayUs for $t {
+        impl ::embedded_hal::delay::DelayNs for $t {
+            fn delay_ns(&mut self, us: u32) {
+                use ::fugit::ExtU64Ceil;
+
+                let now = Self::now();
+                let mut done = now + u64::from(us).nanos_at_least();
+                if now != done {
+                    // Compensate for sub-tick uncertainty
+                    done = done + Self::TICK_PERIOD;
+                }
+
+                while Self::now() < done {}
+            }
+
             fn delay_us(&mut self, us: u32) {
                 use ::fugit::ExtU64Ceil;
 
@@ -87,6 +100,7 @@ macro_rules! embedded_hal_delay_impl_fugit64 {
 
                 while Self::now() < done {}
             }
+
             fn delay_ms(&mut self, ms: u32) {
                 use ::fugit::ExtU64Ceil;
 
@@ -108,7 +122,13 @@ macro_rules! embedded_hal_delay_impl_fugit64 {
 #[macro_export]
 macro_rules! embedded_hal_async_delay_impl_fugit64 {
     ($t:ty) => {
-        impl ::embedded_hal_async::delay::DelayUs for $t {
+        impl ::embedded_hal_async::delay::DelayNs for $t {
+            #[inline]
+            async fn delay_ns(&mut self, us: u32) {
+                use ::fugit::ExtU64Ceil;
+                Self::delay(u64::from(us).nanos_at_least()).await;
+            }
+
             #[inline]
             async fn delay_us(&mut self, us: u32) {
                 use ::fugit::ExtU64Ceil;
@@ -129,7 +149,20 @@ macro_rules! embedded_hal_async_delay_impl_fugit64 {
 #[macro_export]
 macro_rules! embedded_hal_delay_impl_fugit32 {
     ($t:ty) => {
-        impl ::embedded_hal::delay::DelayUs for $t {
+        impl ::embedded_hal::delay::DelayNs for $t {
+            fn delay_ns(&mut self, us: u32) {
+                use ::fugit::ExtU32Ceil;
+
+                let now = Self::now();
+                let mut done = now + us.nanos_at_least();
+                if now != done {
+                    // Compensate for sub-tick uncertainty
+                    done = done + Self::TICK_PERIOD;
+                }
+
+                while Self::now() < done {}
+            }
+
             fn delay_us(&mut self, us: u32) {
                 use ::fugit::ExtU32Ceil;
 
@@ -142,6 +175,7 @@ macro_rules! embedded_hal_delay_impl_fugit32 {
 
                 while Self::now() < done {}
             }
+
             fn delay_ms(&mut self, ms: u32) {
                 use ::fugit::ExtU32Ceil;
 
@@ -163,7 +197,13 @@ macro_rules! embedded_hal_delay_impl_fugit32 {
 #[macro_export]
 macro_rules! embedded_hal_async_delay_impl_fugit32 {
     ($t:ty) => {
-        impl ::embedded_hal_async::delay::DelayUs for $t {
+        impl ::embedded_hal_async::delay::DelayNs for $t {
+            #[inline]
+            async fn delay_ns(&mut self, us: u32) {
+                use ::fugit::ExtU32Ceil;
+                Self::delay(us.nanos_at_least()).await;
+            }
+
             #[inline]
             async fn delay_us(&mut self, us: u32) {
                 use ::fugit::ExtU32Ceil;

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -1,7 +1,5 @@
 //! A monotonic clock / counter definition.
 
-use crate::{TimeoutError, TimerQueue};
-
 /// # A monotonic clock / counter definition.
 ///
 /// ## Correctness

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -6,7 +6,7 @@
 ///
 /// The trait enforces that proper time-math is implemented between `Instant` and `Duration`. This
 /// is a requirement on the time library that the user chooses to use.
-pub trait Monotonic: Sized + 'static {
+pub trait Monotonic {
     /// The time at time zero.
     const ZERO: Self::Instant;
 

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -69,46 +69,6 @@ pub trait Monotonic: Sized + 'static {
     ///
     /// NOTE: This may be called more than once.
     fn disable_timer() {}
-
-    /// Return a reference to the underlying timer queue
-    #[doc(hidden)]
-    fn __tq() -> &'static TimerQueue<Self>;
-
-    /// Delay for some duration of time.
-    #[inline]
-    fn delay(duration: <Self as Monotonic>::Duration) -> impl core::future::Future<Output = ()> {
-        async move {
-            Self::__tq().delay(duration).await;
-        }
-    }
-
-    /// Timeout at a specific time.
-    fn timeout_at<F: core::future::Future>(
-        instant: Self::Instant,
-        future: F,
-    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>> {
-        async move { Self::__tq().timeout_at(instant, future).await }
-    }
-
-    /// Timeout after a specific duration.
-    #[inline]
-    fn timeout_after<F: core::future::Future>(
-        duration: <Self as Monotonic>::Duration,
-        future: F,
-    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>> {
-        async move { Self::__tq().timeout_after(duration, future).await }
-    }
-
-    /// Delay to some specific time instant.
-    #[inline]
-    fn delay_until(
-        instant: <Self as Monotonic>::Instant,
-    ) -> impl core::future::Future<Output = ()> {
-        async move {
-            TimerQueue::<Self>::new();
-            Self::__tq().delay_until(instant).await;
-        }
-    }
 }
 
 /// Creates impl blocks for `embedded_hal::delay::DelayUs`,

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -75,11 +75,11 @@ pub trait Monotonic {
 macro_rules! embedded_hal_delay_impl_fugit64 {
     ($t:ty) => {
         impl ::embedded_hal::delay::DelayNs for $t {
-            fn delay_ns(&mut self, us: u32) {
+            fn delay_ns(&mut self, ns: u32) {
                 use ::fugit::ExtU64Ceil;
 
                 let now = Self::now();
-                let mut done = now + u64::from(us).nanos_at_least();
+                let mut done = now + u64::from(ns).nanos_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
                     done += Self::TICK_PERIOD;
@@ -124,9 +124,9 @@ macro_rules! embedded_hal_async_delay_impl_fugit64 {
     ($t:ty) => {
         impl ::embedded_hal_async::delay::DelayNs for $t {
             #[inline]
-            async fn delay_ns(&mut self, us: u32) {
+            async fn delay_ns(&mut self, ns: u32) {
                 use ::fugit::ExtU64Ceil;
-                Self::delay(u64::from(us).nanos_at_least()).await;
+                Self::delay(u64::from(ns).nanos_at_least()).await;
             }
 
             #[inline]
@@ -150,11 +150,11 @@ macro_rules! embedded_hal_async_delay_impl_fugit64 {
 macro_rules! embedded_hal_delay_impl_fugit32 {
     ($t:ty) => {
         impl ::embedded_hal::delay::DelayNs for $t {
-            fn delay_ns(&mut self, us: u32) {
+            fn delay_ns(&mut self, ns: u32) {
                 use ::fugit::ExtU32Ceil;
 
                 let now = Self::now();
-                let mut done = now + us.nanos_at_least();
+                let mut done = now + ns.nanos_at_least();
                 if now != done {
                     // Compensate for sub-tick uncertainty
                     done += Self::TICK_PERIOD;
@@ -199,9 +199,9 @@ macro_rules! embedded_hal_async_delay_impl_fugit32 {
     ($t:ty) => {
         impl ::embedded_hal_async::delay::DelayNs for $t {
             #[inline]
-            async fn delay_ns(&mut self, us: u32) {
+            async fn delay_ns(&mut self, ns: u32) {
                 use ::fugit::ExtU32Ceil;
-                Self::delay(us.nanos_at_least()).await;
+                Self::delay(ns.nanos_at_least()).await;
             }
 
             #[inline]

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -10,6 +10,9 @@ pub trait Monotonic {
     /// The time at time zero.
     const ZERO: Self::Instant;
 
+    /// The duration between two timer ticks.
+    const TICK_PERIOD: Self::Duration;
+
     /// The type for instant, defining an instant in time.
     ///
     /// **Note:** In all APIs in RTIC that use instants from this monotonic, this type will be used.

--- a/rtic-time/tests/delay_precision_subtick.rs
+++ b/rtic-time/tests/delay_precision_subtick.rs
@@ -174,11 +174,15 @@ macro_rules! subtick_test {
     ($start:expr, $min_duration:expr, $actual_duration:expr) => {{
         subtick_test!(@run $start, $actual_duration, async {
             let mut timer = SubtickTestTimer;
-            embedded_hal_async::delay::DelayUs::delay_ms(&mut timer, $min_duration).await;
+            embedded_hal_async::delay::DelayNs::delay_ms(&mut timer, $min_duration).await;
         });
         subtick_test!(@run $start, $actual_duration, async {
             let mut timer = SubtickTestTimer;
-            embedded_hal_async::delay::DelayUs::delay_us(&mut timer, 1000 * $min_duration).await;
+            embedded_hal_async::delay::DelayNs::delay_us(&mut timer, 1000 * $min_duration).await;
+        });
+        subtick_test!(@run $start, $actual_duration, async {
+            let mut timer = SubtickTestTimer;
+            embedded_hal_async::delay::DelayNs::delay_ns(&mut timer, 1000000 * $min_duration).await;
         });
         subtick_test!(@run $start, $actual_duration, async {
             SubtickTestTimer::delay($min_duration.millis_at_least()).await;

--- a/rtic-time/tests/delay_precision_subtick.rs
+++ b/rtic-time/tests/delay_precision_subtick.rs
@@ -1,0 +1,209 @@
+//! A test that verifies the sub-tick correctness of the [`TimerQueue`]'s `delay` functionality.
+//!
+//! To run this test, you need to activate the `critical-section/std` feature.
+
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+    task::Context,
+};
+
+use cooked_waker::{IntoWaker, WakeRef};
+use embedded_hal_async::delay::DelayUs;
+use parking_lot::Mutex;
+use rtic_time::{Monotonic, TimerQueue};
+
+const SUBTICKS_PER_TICK: u32 = 10;
+struct SubtickTestTimer;
+static TIMER_QUEUE: TimerQueue<SubtickTestTimer> = TimerQueue::new();
+static NOW_SUBTICKS: AtomicU64 = AtomicU64::new(0);
+static COMPARE_TICKS: Mutex<Option<u64>> = Mutex::new(None);
+
+impl Monotonic for SubtickTestTimer {
+    const ZERO: Self::Instant = Self::Instant::from_ticks(0);
+    const TICK_PERIOD: Self::Duration = Self::Duration::from_ticks(1);
+
+    type Instant = fugit::Instant<u64, SUBTICKS_PER_TICK, 1000>;
+    type Duration = fugit::Duration<u64, SUBTICKS_PER_TICK, 1000>;
+
+    fn now() -> Self::Instant {
+        Self::Instant::from_ticks(
+            NOW_SUBTICKS.load(Ordering::Relaxed) / u64::from(SUBTICKS_PER_TICK),
+        )
+    }
+
+    fn set_compare(instant: Self::Instant) {
+        *COMPARE_TICKS.lock() = Some(instant.ticks());
+    }
+
+    fn clear_compare_flag() {}
+
+    fn pend_interrupt() {
+        unsafe {
+            Self::__tq().on_monotonic_interrupt();
+        }
+    }
+
+    fn __tq() -> &'static TimerQueue<Self> {
+        &TIMER_QUEUE
+    }
+}
+
+impl SubtickTestTimer {
+    pub fn init() {
+        Self::__tq().initialize(Self)
+    }
+    pub fn tick() -> u64 {
+        let now = NOW_SUBTICKS.fetch_add(1, Ordering::Relaxed) + 1;
+        let ticks = now / u64::from(SUBTICKS_PER_TICK);
+        let subticks = now % u64::from(SUBTICKS_PER_TICK);
+
+        let compare = COMPARE_TICKS.lock();
+
+        println!(
+            "ticks: {ticks}, subticks: {subticks}, compare: {:?}",
+            *compare
+        );
+        if subticks == 0 && Some(ticks) == *compare {
+            unsafe {
+                Self::__tq().on_monotonic_interrupt();
+            }
+        }
+
+        subticks
+    }
+
+    pub fn forward_to_subtick(subtick: u64) {
+        assert!(subtick < u64::from(SUBTICKS_PER_TICK));
+        while Self::tick() != subtick {}
+    }
+}
+
+rtic_time::embedded_hal_delay_impl_fugit64!(SubtickTestTimer);
+rtic_time::embedded_hal_async_delay_impl_fugit64!(SubtickTestTimer);
+
+// A simple struct that counts the number of times it is awoken. Can't
+// be awoken by value (because that would discard the counter), so we
+// must instead wrap it in an Arc.
+#[derive(Debug, Default)]
+struct WakeCounter {
+    count: AtomicUsize,
+}
+
+impl WakeCounter {
+    fn get(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+impl WakeRef for WakeCounter {
+    fn wake_by_ref(&self) {
+        let _prev = self.count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+macro_rules! subtick_test {
+    ($start:expr, $min_duration:expr, $actual_duration:expr) => {{
+        // forward clock to $start
+        SubtickTestTimer::forward_to_subtick($start);
+        // call wait function
+        let mut timer = SubtickTestTimer;
+
+        let mut delay_ms_fut = std::pin::pin!(timer.delay_ms($min_duration));
+        let delay_ms_wakecounter = Arc::new(WakeCounter::default());
+        let delay_ms_waker = Arc::clone(&delay_ms_wakecounter).into_waker();
+        let mut delay_ms_context = Context::from_waker(&delay_ms_waker);
+
+        let mut finished_after: Option<u64> = None;
+        for i in 0..10 * u64::from(SUBTICKS_PER_TICK) {
+            if Pin::new(&mut delay_ms_fut)
+                .poll(&mut delay_ms_context)
+                .is_ready()
+            {
+                if finished_after.is_none() {
+                    finished_after = Some(i);
+                }
+                break;
+            };
+
+            assert_eq!(delay_ms_wakecounter.get(), 0);
+            SubtickTestTimer::tick();
+        }
+
+        let expected_wakeups = {
+            if $actual_duration == 0 {
+                0
+            } else {
+                1
+            }
+        };
+        assert_eq!(delay_ms_wakecounter.get(), expected_wakeups);
+
+        // Tick again to test that we don't get a second wake
+        SubtickTestTimer::tick();
+        assert_eq!(delay_ms_wakecounter.get(), expected_wakeups);
+
+        println!("Wake Counter: {}", delay_ms_wakecounter.get());
+        assert_eq!(
+            Some($actual_duration),
+            finished_after,
+            "Expected to wait {} ticks, but waited {:?} ticks.",
+            $actual_duration,
+            finished_after,
+        );
+    }};
+}
+
+#[test]
+fn timer_queue_subtick_precision() {
+    SubtickTestTimer::init();
+
+    // subtick_test!(a, b, c) tests the following thing:
+    //
+    // If we start at subtick a and we need to wait b subticks,
+    // then we will actually wait c subticks.
+    // The important part is that c is never smaller than b,
+    // in all cases, as that would violate the contract of
+    // embedded-hal's DelayUs.
+
+    subtick_test!(0, 0, 0);
+    subtick_test!(0, 1, 20);
+    subtick_test!(0, 10, 20);
+    subtick_test!(0, 11, 30);
+    subtick_test!(0, 12, 30);
+
+    subtick_test!(1, 0, 0);
+    subtick_test!(1, 1, 19);
+    subtick_test!(1, 10, 19);
+    subtick_test!(1, 11, 29);
+    subtick_test!(1, 12, 29);
+
+    subtick_test!(2, 0, 0);
+    subtick_test!(2, 1, 18);
+    subtick_test!(2, 10, 18);
+    subtick_test!(2, 11, 28);
+    subtick_test!(2, 12, 28);
+
+    subtick_test!(3, 0, 0);
+    subtick_test!(3, 1, 17);
+    subtick_test!(3, 10, 17);
+    subtick_test!(3, 11, 27);
+    subtick_test!(3, 12, 27);
+
+    subtick_test!(8, 0, 0);
+    subtick_test!(8, 1, 12);
+    subtick_test!(8, 10, 12);
+    subtick_test!(8, 11, 22);
+    subtick_test!(8, 12, 22);
+
+    subtick_test!(9, 0, 0);
+    subtick_test!(9, 1, 11);
+    subtick_test!(9, 10, 11);
+    subtick_test!(9, 11, 21);
+    subtick_test!(9, 12, 21);
+}

--- a/rtic-time/tests/timer_queue.rs
+++ b/rtic-time/tests/timer_queue.rs
@@ -211,7 +211,8 @@ fn timer_queue() {
             let elapsed = start.elapsed().as_ticks();
             println!("{total_millis} ticks delay reached after {elapsed} ticks");
 
-            if elapsed != total_millis {
+            // Expect a delay of one longer, to compensate for timer uncertainty
+            if elapsed != total_millis + 1 {
                 panic!(
                     "{total_millis} ticks delay was not on time ({elapsed} ticks passed instead)"
                 );
@@ -264,25 +265,25 @@ fn timer_queue() {
 
         if Instant::now() == 0.into() {
             // First, we want to be waiting for our 300 tick delay
-            assert_eq!(TestMono::compare(), Some(300.into()));
+            assert_eq!(TestMono::compare(), Some(301.into()));
         }
 
         if Instant::now() == 100.into() {
             // After 100 ticks, we enqueue a new delay that is supposed to last
             // until the 200-tick-mark
-            assert_eq!(TestMono::compare(), Some(200.into()));
+            assert_eq!(TestMono::compare(), Some(201.into()));
         }
 
-        if Instant::now() == 200.into() {
+        if Instant::now() == 201.into() {
             // After 200 ticks, we dequeue the 200-tick-mark delay and
             // requeue the 300 tick delay
-            assert_eq!(TestMono::compare(), Some(300.into()));
+            assert_eq!(TestMono::compare(), Some(301.into()));
         }
 
-        if Instant::now() == 300.into() {
+        if Instant::now() == 301.into() {
             // After 300 ticks, we dequeue the 300-tick-mark delay and
             // go to the 400 tick delay that is already enqueued
-            assert_eq!(TestMono::compare(), Some(400.into()));
+            assert_eq!(TestMono::compare(), Some(401.into()));
         }
     }
 

--- a/rtic-time/tests/timer_queue.rs
+++ b/rtic-time/tests/timer_queue.rs
@@ -17,7 +17,7 @@ static NOW: Mutex<Option<Instant>> = Mutex::new(None);
 pub struct Duration(u64);
 
 impl Duration {
-    pub fn from_ticks(millis: u64) -> Self {
+    pub const fn from_ticks(millis: u64) -> Self {
         Self(millis)
     }
 
@@ -161,6 +161,7 @@ impl TestMono {
 
 impl Monotonic for TestMono {
     const ZERO: Self::Instant = Instant::ZERO;
+    const TICK_PERIOD: Self::Duration = Duration::from_ticks(1);
 
     type Instant = Instant;
 

--- a/rtic-time/tests/timer_queue.rs
+++ b/rtic-time/tests/timer_queue.rs
@@ -180,10 +180,6 @@ impl Monotonic for TestMono {
     fn pend_interrupt() {
         Self::tick(true);
     }
-
-    fn __tq() -> &'static TimerQueue<Self> {
-        Self::queue()
-    }
 }
 
 #[test]

--- a/rtic-time/tests/timer_queue.rs
+++ b/rtic-time/tests/timer_queue.rs
@@ -180,6 +180,10 @@ impl Monotonic for TestMono {
     fn pend_interrupt() {
         Self::tick(true);
     }
+
+    fn __tq() -> &'static TimerQueue<Self> {
+        Self::queue()
+    }
 }
 
 #[test]

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -11,6 +11,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Unstable support for ESP32-C3
 
 ### Fixed
+- **Soundness fix:** Monotonics did not wait long enough in `Duration` based delays.
+  This is not directly a change for `rtic`, but required bumping the minimal version of `rtic-monotonics`.
 
 ### Changed
 

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -8,9 +8,11 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ## [Unreleased]
 
 ### Added
+
 - Unstable support for ESP32-C3
 
 ### Fixed
+
 - **Soundness fix:** Monotonics did not wait long enough in `Duration` based delays.
   This is not directly a change for `rtic`, but required bumping the minimal version of `rtic-monotonics`.
 

--- a/rtic/ci/expected/async-timeout.run
+++ b/rtic/ci/expected/async-timeout.run
@@ -5,12 +5,12 @@ the hal takes a duration of Duration { ticks: 45 }
 hal returned 5
 the hal takes a duration of Duration { ticks: 45 }
 hal returned 5
-now is Instant { ticks: 210 }, timeout at Instant { ticks: 260 }
+now is Instant { ticks: 213 }, timeout at Instant { ticks: 263 }
 the hal takes a duration of Duration { ticks: 35 }
-hal returned 5 at time Instant { ticks: 245 }
-now is Instant { ticks: 310 }, timeout at Instant { ticks: 360 }
+hal returned 5 at time Instant { ticks: 249 }
+now is Instant { ticks: 313 }, timeout at Instant { ticks: 363 }
 the hal takes a duration of Duration { ticks: 45 }
-hal returned 5 at time Instant { ticks: 355 }
-now is Instant { ticks: 410 }, timeout at Instant { ticks: 460 }
+hal returned 5 at time Instant { ticks: 359 }
+now is Instant { ticks: 413 }, timeout at Instant { ticks: 463 }
 the hal takes a duration of Duration { ticks: 55 }
 timeout


### PR DESCRIPTION
Fixes #844.

# Solution
- Compensate for timer uncertainty by always waiting for one extra timer tick.
- Replace all `.micros()` with `.micros_at_least()` and all `.millis()` with `.millis_at_least()`.

# Open questions / Problems
- [x] This is technically a breaking change for `rtic-time`, and indirectly therefore also for `rtic-monotonics` and `rtic` itself. This would require all of those to be updated to a new major version.
    - **Answer:** It's a soundness issue, so it is fine to release it as a patch.
- [x] The previous versions technically did not comply with `embedded-hal`'s definitions of `DelayX`. So should we yank those?
    - **Answer:** Yes. Let's yank previous versions.