### PR TITLE
rtic-sync Arbiter: impl more I2C trait fns

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -9,8 +9,8 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Added
 
-- `arbiter::spi::ArbiterDevice` for sharing SPI buses using `embedded-hal-async`
-- `arbiter::i2c::ArbiterDevice` for sharing I2C buses using `embedded-hal-async`
+- `arbiter::spi::ArbiterDevice` for sharing SPI buses using `embedded-hal-async` traits.
+- `arbiter::i2c::ArbiterDevice` for sharing I2C buses using `embedded-hal-async` traits.
 
 ### Changed
 

--- a/rtic-sync/src/arbiter.rs
+++ b/rtic-sync/src/arbiter.rs
@@ -352,6 +352,26 @@ pub mod i2c {
         BUS: I2c<A>,
         A: AddressMode,
     {
+        async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+            let mut bus = self.bus.access().await;
+            bus.read(address, read).await
+        }
+
+        async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+            let mut bus = self.bus.access().await;
+            bus.write(address, write).await
+        }
+
+        async fn write_read(
+            &mut self,
+            address: A,
+            write: &[u8],
+            read: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            let mut bus = self.bus.access().await;
+            bus.write_read(address, write, read).await
+        }
+
         async fn transaction(
             &mut self,
             address: A,


### PR DESCRIPTION
For example embassy-stm32 I2C [does not impl transaction yet](https://github.com/embassy-rs/embassy/blob/main/embassy-stm32/src/i2c/mod.rs#L200) but other functions are available. So it would be better to implement all I2c trait functions.