### PR TITLE
Fix `nrf::rtc` errata workaround

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -9,8 +9,9 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
-- Race condition in `nrf::timer`.
-- Race condition in `nrf::rtc`.
+- Fix Race condition in `nrf::timer`.
+- Fix Race condition in `nrf::rtc`.
+- Fix errata in `nrf::rtc`.
 - Add internal counter integrity check to all half-period based monotonics.
 
 ## v1.4.0 - 2023-12-04

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -9,8 +9,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
-- Fix Race condition in `nrf::timer`.
-- Fix Race condition in `nrf::rtc`.
+- Fix race condition in `nrf::timer`.
+- Fix race condition in `nrf::rtc`.
 - Fix errata in `nrf::rtc`.
 - Add internal counter integrity check to all half-period based monotonics.
 

--- a/rtic-time/CHANGELOG.md
+++ b/rtic-time/CHANGELOG.md
@@ -12,6 +12,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Changed
 
 - Docs: Add sanity check to `half_period_counter` code example
+- Deprecate `Monotonic::should_dequeue_check` as it was erroneous
 
 ### Fixed
 

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtic-time"
-version = "1.1.0"
+version = "1.2.0"
 
 edition = "2021"
 authors = [

--- a/rtic-time/src/lib.rs
+++ b/rtic-time/src/lib.rs
@@ -133,7 +133,7 @@ impl<Mono: Monotonic> TimerQueue<Mono> {
             let head = self.queue.pop_if(|head| {
                 release_at = Some(head.release_at);
 
-                let should_pop = Mono::should_dequeue_check(head.release_at);
+                let should_pop = Mono::now() >= head.release_at;
                 head.was_popped.store(should_pop, Ordering::Relaxed);
 
                 should_pop
@@ -147,7 +147,7 @@ impl<Mono: Monotonic> TimerQueue<Mono> {
                     Mono::enable_timer();
                     Mono::set_compare(instant);
 
-                    if Mono::should_dequeue_check(instant) {
+                    if Mono::now() >= instant {
                         // The time for the next instant passed while handling it,
                         // continue dequeueing
                         continue;

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -36,11 +36,15 @@ pub trait Monotonic {
     /// queue in RTIC checks this.
     fn set_compare(instant: Self::Instant);
 
-    /// Override for the dequeue check, override with timers that have bugs.
-    ///
-    /// E.g. nRF52 RTCs needs to be dequeued if the time is within 4 ticks.
-    fn should_dequeue_check(release_at: Self::Instant) -> bool {
-        <Self as Monotonic>::now() >= release_at
+    /// This method used to be required by an errata workaround
+    /// for the nrf52 family, but it has been disabled as the
+    /// workaround was erroneous.
+    #[deprecated(
+        since = "1.2.0",
+        note = "this method is erroneous and has been disabled"
+    )]
+    fn should_dequeue_check(_: Self::Instant) -> bool {
+        panic!("This method should not be used as it is erroneous.")
     }
 
     /// Clear the compare interrupt flag.


### PR DESCRIPTION
The problem is that the RTC peripheral will not properly deliver an interrupt if the scheduled compare is less than two ticks in the future. Together with the timer uncertainty it was determined that it is necessary to schedule always at least `now + 3` ticks in the future.

The current workaround, however, did the following. If it checked the queue and if there is a delay in the queue that is less than 3 ticks in the future, it will dequeue it. This means that the delay will only get re-checked and released at whatever timer interrupt comes in the future, or not at all if it was the last thing to ever wait for, causing a deadlock.

This was the current behavior when scheduling a bunch of delays all at once:
```rust
// <desired_release_time_ticks> => <actual_release_time_ticks>
 50 =>  50
100 => 100
101 => 150
150 => 150
200 => 200
201 => ... never
```

This is obviously not desired behavior.

With the rework, the same situation now plays out as follows:
```rust
// <desired_release_time_ticks> => <actual_release_time_ticks>
 50 =>  50
100 => 100
101 => 103
150 => 150
200 => 200
201 => 203
```

Fixes #851.