### PR TITLE
Changes `make_channel!` macro to accept more types

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -13,6 +13,8 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Fixed
 
+- `make_channel` now accepts `Type` expressions instead of only `TypePath` expressions.
+
 ## v1.1.1 - 2023-12-04
 
 ### Fixed

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -104,7 +104,7 @@ impl<T, const N: usize> Channel<T, N> {
 /// Creates a split channel with `'static` lifetime.
 #[macro_export]
 macro_rules! make_channel {
-    ($type:path, $size:expr) => {{
+    ($type:ty, $size:expr) => {{
         static mut CHANNEL: $crate::channel::Channel<$type, $size> =
             $crate::channel::Channel::new();
 
@@ -595,5 +595,10 @@ mod tests {
     fn double_make_channel() {
         make();
         make();
+    }
+
+    #[test]
+    fn tuple_channel() {
+        let _ = make_channel!((i32, u32), 10);
     }
 }


### PR DESCRIPTION
Changes `type` macro argument from `path` to `ty`, allowing more complex types like tuples, arrays, & pointers.

See https://doc.rust-lang.org/reference/types.html#type-expressions.