### PR TITLE
rtic-macros: fix #[cfg] for hardware and software tasks

### DIFF
--- a/ci/expected/lm3s6965/t-cfg-tasks.size
+++ b/ci/expected/lm3s6965/t-cfg-tasks.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4268	      0	      4	   4272	   10b0	t-cfg-tasks

--- a/examples/lm3s6965/Cargo.lock
+++ b/examples/lm3s6965/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "rtic"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "atomic-polyfill",
  "bare-metal 1.0.0",

--- a/examples/lm3s6965/Cargo.lock
+++ b/examples/lm3s6965/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "rtic-sync"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",

--- a/examples/lm3s6965/examples/t-cfg-tasks.rs
+++ b/examples/lm3s6965/examples/t-cfg-tasks.rs
@@ -1,0 +1,35 @@
+//! [compile-pass] check that `#[cfg]` attributes applied on tasks work
+
+#![no_main]
+#![no_std]
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+
+use panic_semihosting as _;
+
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0])]
+mod app {
+    use cortex_m_semihosting::debug;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator
+
+        (Shared {}, Local {})
+    }
+
+    #[cfg(feature = "feature_x")]
+    #[task]
+    async fn opt_sw_task(cx: opt_sw_task::Context) {}
+
+    #[cfg(feature = "feature_x")]
+    #[task(binds = UART0)]
+    fn opt_hw_task(cx: opt_hw_task::Context) {}
+}

--- a/examples/lm3s6965/examples/t-cfg-tasks.rs
+++ b/examples/lm3s6965/examples/t-cfg-tasks.rs
@@ -5,6 +5,7 @@
 #![deny(warnings)]
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
+#![allow(unexpected_cfgs)]
 
 use panic_semihosting as _;
 

--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `#[cfg]` tags on hardware and software tasks.
+
 ## [v2.1.0] - 2024-02-27
 
 ### Added

--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- Fixed `#[cfg]` tags on hardware and software tasks.
 - Generated `panic`s can no longer be shadowed. Previously, they were inconsistently shadowed.
 - Generated mutexes for shared resourses no longer implement `Send`. They are meant to be used inside a task locally.
 

--- a/rtic-macros/src/codegen/hardware_tasks.rs
+++ b/rtic-macros/src/codegen/hardware_tasks.rs
@@ -73,10 +73,12 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
 
         if !task.is_extern {
             let attrs = &task.attrs;
+            let cfgs = &task.cfgs;
             let context = &task.context;
             let stmts = &task.stmts;
             user_tasks.push(quote!(
                 #(#attrs)*
+                #(#cfgs)*
                 #[allow(non_snake_case)]
                 fn #name(#context: #name::Context) {
                     use rtic::Mutex as _;

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `#[cfg]` tags on hardware and software tasks.
+
 ## [v2.1.1] - 2024-03-13
 
 ### Fixed

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -30,6 +30,10 @@ Example:
 - Removed `bare_metal` in favour of `critical_section`.
 - Updated esp32c3 dependency to v0.30.0
 - Updated esp32c6 dependency to v0.21.0
+ 
+### Fixed
+
+- Fixed `#[cfg]` tags on hardware and software tasks.
 
 ## [v2.2.0] - 2025-06-22
 


### PR DESCRIPTION
Hi,

Disabling hardware and software tasks via `#[cfg]` flags was broken. Added test case to verify, and fixed codegen to output missing cfgs.

Best regards,
Lasse