### PR TITLE
Docs: Rename `DelayUs` to `DelayNs` in docs for macros.

### DIFF
--- a/rtic-time/CHANGELOG.md
+++ b/rtic-time/CHANGELOG.md
@@ -13,6 +13,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- Docs: Rename `DelayUs` to `DelayNs` in docs.
+
 ## v1.3.0 - 2024-01-10
 
 ### Changed

--- a/rtic-time/src/monotonic.rs
+++ b/rtic-time/src/monotonic.rs
@@ -73,8 +73,11 @@ pub trait Monotonic {
     fn disable_timer() {}
 }
 
-/// Creates impl blocks for `embedded_hal::delay::DelayUs`,
-/// based on `fugit::ExtU64Ceil`.
+/// Creates impl blocks for [`embedded_hal::delay::DelayNs`][DelayNs],
+/// based on [`fugit::ExtU64Ceil`][ExtU64Ceil].
+///
+/// [DelayNs]: https://docs.rs/embedded-hal/latest/embedded_hal/delay/trait.DelayNs.html
+/// [ExtU64Ceil]: https://docs.rs/fugit/latest/fugit/trait.ExtU64Ceil.html
 #[macro_export]
 macro_rules! embedded_hal_delay_impl_fugit64 {
     ($t:ty) => {
@@ -121,8 +124,11 @@ macro_rules! embedded_hal_delay_impl_fugit64 {
     };
 }
 
-/// Creates impl blocks for `embedded_hal_async::delay::DelayUs`,
-/// based on `fugit::ExtU64Ceil`.
+/// Creates impl blocks for [`embedded_hal_async::delay::DelayNs`][DelayNs],
+/// based on [`fugit::ExtU64Ceil`][ExtU64Ceil].
+///
+/// [DelayNs]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/delay/trait.DelayNs.html
+/// [ExtU64Ceil]: https://docs.rs/fugit/latest/fugit/trait.ExtU64Ceil.html
 #[macro_export]
 macro_rules! embedded_hal_async_delay_impl_fugit64 {
     ($t:ty) => {
@@ -148,8 +154,11 @@ macro_rules! embedded_hal_async_delay_impl_fugit64 {
     };
 }
 
-/// Creates impl blocks for `embedded_hal::delay::DelayUs`,
-/// based on `fugit::ExtU32Ceil`.
+/// Creates impl blocks for [`embedded_hal::delay::DelayNs`][DelayNs],
+/// based on [`fugit::ExtU32Ceil`][ExtU32Ceil].
+///
+/// [DelayNs]: https://docs.rs/embedded-hal/latest/embedded_hal/delay/trait.DelayNs.html
+/// [ExtU32Ceil]: https://docs.rs/fugit/latest/fugit/trait.ExtU32Ceil.html
 #[macro_export]
 macro_rules! embedded_hal_delay_impl_fugit32 {
     ($t:ty) => {
@@ -196,8 +205,11 @@ macro_rules! embedded_hal_delay_impl_fugit32 {
     };
 }
 
-/// Creates impl blocks for `embedded_hal_async::delay::DelayUs`,
-/// based on `fugit::ExtU32Ceil`.
+/// Creates impl blocks for [`embedded_hal_async::delay::DelayNs`][DelayNs],
+/// based on [`fugit::ExtU32Ceil`][ExtU32Ceil].
+///
+/// [DelayNs]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/delay/trait.DelayNs.html
+/// [ExtU32Ceil]: https://docs.rs/fugit/latest/fugit/trait.ExtU32Ceil.html
 #[macro_export]
 macro_rules! embedded_hal_async_delay_impl_fugit32 {
     ($t:ty) => {

--- a/rtic-time/tests/delay_precision_subtick.rs
+++ b/rtic-time/tests/delay_precision_subtick.rs
@@ -273,7 +273,7 @@ fn timer_queue_subtick_precision() {
     // then we will actually wait c subticks.
     // The important part is that c is never smaller than b,
     // in all cases, as that would violate the contract of
-    // embedded-hal's DelayUs.
+    // embedded-hal's DelayNs.
 
     subtick_test!(0, 0, 0);
     subtick_test!(0, 1, 20);


### PR DESCRIPTION
1. Rename `DelayUs` to `DelayNs` in docs for macros. The code uses the correct name, only the docs were one letter off.
2. I also turned `DelayNs` and `ExtU32Ceil` into links to the upstream documentation.