### PR TITLE
CI: Add ESP32-C3 QEMU support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ env:
   OLDOLDOLDSTABLE_VERSION: 0.4
   QEMU_VERSION: 8.2.0
   QEMU_URL: https://download.qemu.org/qemu-8.2.0.tar.xz
+  QEMU_ESP: qemu_esp
+  QEMU_ESP_URL: https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz
 
 jobs:
   # Run cargo xtask format-check
@@ -230,7 +232,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y qemu-system-arm qemu-system-riscv32
-          sudo apt-get install git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
+          sudo apt install -y git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
 
       - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
         name: Download QEMU
@@ -250,8 +252,16 @@ jobs:
         name: Build QEMU
         run: |
           cd qemu-${{ env.QEMU_VERSION }}
-          make -j$(nproc)
+          ninja -C build
           
+      - name: Download ESP32 QEMU
+        run: wget "${{ env.QEMU_ESP_URL }}" --output-document=${{ env.QEMU_ESP}}.tar.xz
+
+      - name: Extract ESP32 QEMU
+        run: |
+          mkdir -p qemu-${{ env.QEMU_VERSION }}/build/esp32
+          tar --strip-components=1 -xvJf ${{ env.QEMU_ESP }}.tar.xz -C qemu-${{ env.QEMU_VERSION }}/build/esp32 qemu
+
       - name: Archive QEMU build
         run: |
           cd qemu-${{ env.QEMU_VERSION }}/build
@@ -385,6 +395,75 @@ jobs:
       - name: Run-pass tests
         if: ${{ matrix.backend != 'riscv32-imc-clint' }}
         run: cargo xtask --deny-warnings --platform hifive1 --backend ${{ matrix.backend }} qemu
+
+  # Platform esp32c3: verify the example output with run-pass tests
+  testexamplesesp32c3:
+    name: QEMU run (esp32c3)
+    needs: buildqemu
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust ${{ matrix.toolchain }}
+        run: |
+          rustup set profile minimal
+          rustup override set ${{ matrix.toolchain }}
+
+      - name: Configure Rust target
+        run: |
+          rustup target add riscv32imac-unknown-none-elf
+          rustup target add riscv32imc-unknown-none-elf
+
+      - name: Add Rust component llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+
+      - name: Install libudev espflash dependency
+        run: |
+          sudo apt update
+          sudo apt install -y libudev-dev
+
+      # Use precompiled binutils
+      - name: Install cargo-binutils
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binutils
+
+      # Use precompiled if possible
+      - name: Install cargo-binutils
+        uses: taiki-e/install-action@v2
+        with:
+          tool: espflash
+
+      - name: Install esptool.py
+        run: pip install esptool
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install QEMU to get dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-system-riscv32
+
+      - name: Download built QEMU
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu
+      
+      - name: Extract ESP32 QEMU into local path
+        run: sudo tar --strip-components=1 -xf qemu.tar -C /usr/local/ esp32/
+
+      - name: Check which QEMU is used
+        run: |
+          which qemu-system-riscv32
+      
+      - name: Run-pass tests
+        run: cargo xtask -vvv --platform esp32-c3 qemu
 
   # Run test suite
   tests:
@@ -829,6 +908,7 @@ jobs:
       - checkexamplesesp32c3
       - testexampleslm3s6965
       - testexampleshifive1
+      - testexamplesesp32c3
       - tests
       - docs
       - mdbook

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ book-target/
 
 .DS_Store
 .vscode/
+qemu.log

--- a/ci/expected/esp32c3/sw_and_hw.run
+++ b/ci/expected/esp32c3/sw_and_hw.run
@@ -1,0 +1,36 @@
+QEMU 8.2.0 monitor - type 'help' for more information
+(qemu) q[K
+ESP-ROM:esp32c3-api1-20210207
+Build:Feb  7 2021
+rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
+SPIWP:0xee
+mode:DIO, clock div:2
+load:0x3fcd5820,len:0x1714
+load:0x403cc710,len:0x968
+load:0x403ce710,len:0x2f9c
+entry 0x403cc710
+[0;32mI (0) boot: ESP-IDF v5.1.2-342-gbcf1645e44 2nd stage bootloader[0m
+[0;32mI (0) boot: compile time Dec 12 2023 10:50:58[0m
+[0;32mI (0) boot: chip revision: v0.3[0m
+[0;32mI (0) boot.esp32c3: SPI Speed      : 40MHz[0m
+[0;32mI (0) boot.esp32c3: SPI Mode       : SLOW READ[0m
+[0;32mI (0) boot.esp32c3: SPI Flash Size : 4MB[0m
+[0;32mI (0) boot: Enabling RNG early entropy source...[0m
+[0;32mI (1) boot: Partition Table:[0m
+[0;32mI (1) boot: ## Label            Usage          Type ST Offset   Length[0m
+[0;32mI (1) boot:  0 nvs              WiFi data        01 02 00009000 00006000[0m
+[0;32mI (1) boot:  1 phy_init         RF data          01 01 0000f000 00001000[0m
+[0;32mI (1) boot:  2 factory          factory app      00 00 00010000 003f0000[0m
+[0;32mI (1) boot: End of partition table[0m
+[0;32mI (1) esp_image: segment 0: paddr=00010020 vaddr=3c010020 size=022e4h (  8932) map[0m
+[0;32mI (3) esp_image: segment 1: paddr=0001230c vaddr=40380000 size=01250h (  4688) load[0m
+[0;32mI (3) esp_image: segment 2: paddr=00013564 vaddr=00000000 size=0cab4h ( 51892) [0m
+[0;32mI (8) esp_image: segment 3: paddr=00020020 vaddr=42000020 size=05db4h ( 23988) map[0m
+[0;32mI (11) boot: Loaded app from partition at offset 0x10000[0m
+[0;32mI (11) boot: Disabling RNG early entropy source...[0m
+init
+Inside high prio task, press button now!
+Leaving high prio task.
+idle
+Inside low prio task, press button now!
+Leaving low prio task.

--- a/examples/esp32c3/.cargo/config.toml
+++ b/examples/esp32c3/.cargo/config.toml
@@ -1,5 +1,9 @@
 [target.riscv32imc-unknown-none-elf]
-runner = "espflash flash --monitor"
+# Real hardware
+#runner = "espflash flash --monitor"
+
+# QEMU emulator
+runner = "./runner.sh"
 
 [build]
 rustflags = [

--- a/examples/esp32c3/runner.sh
+++ b/examples/esp32c3/runner.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied! Provide path to ELF as argument"
+fi
+
+outputfilenamecargo=$1
+outputfilename="$outputfilenamecargo".bin
+
+logfile=qemu.log
+
+qemuexec=qemu-system-riscv32
+
+# Building ESP32-C3 image
+espflash save-image --chip esp32c3 --merge "$outputfilenamecargo" "$outputfilename" 1>&2
+
+# Get stats
+esptool.py image_info --version 2 "$outputfilename" 1>&2
+
+# Run in QEMU
+$qemuexec -nographic -monitor tcp:127.0.0.1:55555,server,nowait -icount 3 -machine esp32c3 -drive file="$outputfilename",if=mtd,format=raw  -serial file:"$logfile" &
+
+# Let it run
+sleep 3s
+
+# Kill QEMU nicely by sending 'q' (quit) over tcp
+echo q | nc -N 127.0.0.1 55555
+cat "$logfile"


### PR DESCRIPTION
Use [forked and patched QEMU from espressif](https://github.com/espressif/qemu)

- **CI: ESP32-C3: QEMU support**
- **CI: ESP32C3: Script for preparing and running**
- **CI: gitignore qemu.log**
- **ESP32-C3: Example sw_and_hw output**
