### PR TITLE
Fix clippy::assign_op_pattern lint

### DIFF
--- a/rtic-time/src/monotonic/embedded_hal_macros.rs
+++ b/rtic-time/src/monotonic/embedded_hal_macros.rs
@@ -11,7 +11,7 @@ macro_rules! impl_embedded_hal_delay_fugit {
                     now + <Self as $crate::Monotonic>::Duration::nanos_at_least(ns.into());
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + <Self as $crate::Monotonic>::Duration::from_ticks(1);
+                    done += <Self as $crate::Monotonic>::Duration::from_ticks(1);
                 }
 
                 while <Self as $crate::Monotonic>::now() < done {}
@@ -35,7 +35,7 @@ macro_rules! impl_embedded_hal_delay_fugit {
                     now + <Self as $crate::Monotonic>::Duration::millis_at_least(ms.into());
                 if now != done {
                     // Compensate for sub-tick uncertainty
-                    done = done + <Self as $crate::Monotonic>::Duration::from_ticks(1);
+                    done += <Self as $crate::Monotonic>::Duration::from_ticks(1);
                 }
 
                 while <Self as $crate::Monotonic>::now() < done {}


### PR DESCRIPTION
When I try to use rtic-monotonics, I got this warning from clippy.

```
warning: manual implementation of an assign operation
  --> src\main.rs:52:1
   |
52 | rp2040_timer_monotonic!(Mono);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
   = note: this warning originates in the macro `$crate::rtic_time::impl_embedded_hal_delay_fugit` which comes from the expansion of the macro `rp2040_timer_monotonic` (in Nightly builds, run with -Z macro-backtrace for more info)
```