### PR TITLE
Add Signal to rtic-sync

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -14,6 +14,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 ### Added
 
 - `defmt v0.3` derives added and forwarded to `embedded-hal(-x)` crates.
+- signal structure
 
 ## v1.2.0 - 2024-01-10
 

--- a/rtic-sync/Cargo.toml
+++ b/rtic-sync/Cargo.toml
@@ -29,6 +29,7 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"] }
 defmt-03 = { package = "defmt", version = "0.3", optional = true }
 
 [dev-dependencies]
+static_cell = "2.1.0"
 tokio = { version = "1", features = ["rt", "macros", "time"] }
 
 [features]

--- a/rtic-sync/src/lib.rs
+++ b/rtic-sync/src/lib.rs
@@ -9,6 +9,7 @@ use defmt_03 as defmt;
 pub mod arbiter;
 pub mod channel;
 pub use portable_atomic;
+pub mod signal;
 
 #[cfg(test)]
 #[macro_use]

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -1,0 +1,148 @@
+//! A "latest only" value store with unlimited writers and async waiting.
+//!
+//! Example usage:
+//!
+//! ```rust
+//! fn init(ctx: init::Context) -> (Shared, Local) {
+//!     // mono set up among other things...
+//!
+//!     let (writer, reader) = make_signal!(u8);
+//!
+//!     writer_task::spawn(writer);
+//!     reader_task::spawn(reader);
+//! }
+//!
+//! #[task]
+//! async fn writer_task(_ctx: writer_task::Context, mut writer: SignalWriter<u8>) {
+//!     for i in 0..10 {
+//!         writer.write(i);
+//!         Mono::delay(500.millis()).await;
+//!     }
+//! }
+//!
+//! #[task]
+//! async fn reader_task(_ctx: reader_task::Context, mut reader: SignalReader<u8>) {
+//!     loop {
+//!         let value = reader.wait().await;
+//!         defmt::info("received value: {}", value);
+//!     }
+//! }
+//! ```
+
+use core::{
+    cell::UnsafeCell,
+    future::poll_fn,
+    sync::atomic::{fence, Ordering},
+    task::Poll,
+};
+use rtic_common::waker_registration::CriticalSectionWakerRegistration;
+
+/// Basically an Option but for indicating
+/// whether the store has been set or not
+#[derive(Clone, Copy)]
+enum Store<T> {
+    Set(T),
+    Unset,
+}
+
+/// An async message passing structure with unlimited writers and one reader.
+pub struct Signal<T: Copy> {
+    waker: CriticalSectionWakerRegistration,
+    store: UnsafeCell<Store<T>>,
+}
+
+unsafe impl<T: Copy> Send for Signal<T> {}
+unsafe impl<T: Copy> Sync for Signal<T> {}
+
+impl<T: Copy> Signal<T> {
+    /// Create a new signal.
+    pub const fn new() -> Self {
+        Self {
+            waker: CriticalSectionWakerRegistration::new(),
+            store: UnsafeCell::new(Store::Unset),
+        }
+    }
+
+    /// Split the signal into a writer and reader.
+    pub fn split(&'static self) -> (SignalWriter<T>, SignalReader<T>) {
+        (SignalWriter { parent: self }, SignalReader { parent: self })
+    }
+}
+
+/// Fascilitates the writing of values to a Signal.
+#[derive(Clone)]
+pub struct SignalWriter<T: 'static + Copy> {
+    parent: &'static Signal<T>,
+}
+
+impl<T: Copy> SignalWriter<T> {
+    /// Write a raw Store value to the Signal.
+    fn write_inner(&mut self, value: Store<T>) {
+        fence(Ordering::SeqCst);
+
+        critical_section::with(|_| {
+            // SAFETY: in a cs: exclusive access
+            unsafe { self.parent.store.get().replace(value) };
+        });
+
+        self.parent.waker.wake();
+    }
+
+    /// Write a value to the Signal.
+    pub fn write(&mut self, value: T) {
+        self.write_inner(Store::Set(value));
+    }
+
+    /// Clear the stored value in the Signal (if any).
+    pub fn clear(&mut self) {
+        self.write_inner(Store::Unset);
+    }
+}
+
+/// Fascilitates the async reading of values from the Signal.
+pub struct SignalReader<T: 'static + Copy> {
+    parent: &'static Signal<T>,
+}
+
+impl<T: Copy> SignalReader<T> {
+    /// Immediately read and evict the latest value stored in the Signal.
+    fn take(&mut self) -> Store<T> {
+        critical_section::with(|_| {
+            // SAFETY: in a cs: exclusive access
+            unsafe { self.parent.store.get().replace(Store::Unset) }
+        })
+    }
+
+    /// Wait for a new value to be written and read it.
+    ///
+    /// If a value is already pending it will be returned immediately.
+    pub async fn wait(&mut self) -> T {
+        poll_fn(|ctx| match self.take() {
+            Store::Unset => {
+                self.parent.waker.register(ctx.waker());
+                Poll::Pending
+            }
+            Store::Set(value) => Poll::Ready(value),
+        })
+        .await
+    }
+
+    /// Wait for a new value to be written and read it.
+    ///
+    /// If a value is already pending, it will be evicted and a new
+    /// value must be written for the wait to resolve.
+    pub async fn wait_fresh(&mut self) -> T {
+        self.take();
+        self.wait().await
+    }
+}
+
+/// Convenience macro for creating a Signal.
+#[macro_export]
+macro_rules! make_signal {
+    ( $T:ty ) => {{
+        static SIGNAL: Signal<$T> = Signal::new();
+
+        SIGNAL.split()
+    }};
+}

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -30,7 +30,7 @@ impl<T: Copy> Signal<T> {
     }
 
     /// Split the signal into a writer and reader.
-    pub fn split<'a>(&'a self) -> (SignalWriter<T>, SignalReader<T>) {
+    pub fn split(&self) -> (SignalWriter<T>, SignalReader<T>) {
         (SignalWriter { parent: self }, SignalReader { parent: self })
     }
 }

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -1,11 +1,6 @@
 //! A "latest only" value store with unlimited writers and async waiting.
 
-use core::{
-    cell::UnsafeCell,
-    future::poll_fn,
-    sync::atomic::{fence, Ordering},
-    task::Poll,
-};
+use core::{cell::UnsafeCell, future::poll_fn, task::Poll};
 use rtic_common::waker_registration::CriticalSectionWakerRegistration;
 
 /// Basically an Option but for indicating
@@ -49,8 +44,6 @@ pub struct SignalWriter<'a, T: Copy> {
 impl<'a, T: Copy> SignalWriter<'a, T> {
     /// Write a raw Store value to the Signal.
     fn write_inner(&mut self, value: Store<T>) {
-        fence(Ordering::SeqCst);
-
         critical_section::with(|_| {
             // SAFETY: in a cs: exclusive access
             unsafe { self.parent.store.get().replace(value) };

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -1,33 +1,4 @@
 //! A "latest only" value store with unlimited writers and async waiting.
-//!
-//! Example usage:
-//!
-//! ```rust
-//! fn init(ctx: init::Context) -> (Shared, Local) {
-//!     // mono set up among other things...
-//!
-//!     let (writer, reader) = make_signal!(u8);
-//!
-//!     writer_task::spawn(writer);
-//!     reader_task::spawn(reader);
-//! }
-//!
-//! #[task]
-//! async fn writer_task(_ctx: writer_task::Context, mut writer: SignalWriter<u8>) {
-//!     for i in 0..10 {
-//!         writer.write(i);
-//!         Mono::delay(500.millis()).await;
-//!     }
-//! }
-//!
-//! #[task]
-//! async fn reader_task(_ctx: reader_task::Context, mut reader: SignalReader<u8>) {
-//!     loop {
-//!         let value = reader.wait().await;
-//!         defmt::info("received value: {}", value);
-//!     }
-//! }
-//! ```
 
 use core::{
     cell::UnsafeCell,
@@ -45,7 +16,7 @@ enum Store<T> {
     Unset,
 }
 
-/// An async message passing structure with unlimited writers and one reader.
+/// A "latest only" value store with unlimited writers and async waiting.
 pub struct Signal<T: Copy> {
     waker: CriticalSectionWakerRegistration,
     store: UnsafeCell<Store<T>>,


### PR DESCRIPTION
Add the Signal structure to rtic-sync.

A Signal has unlimited writers and one reader, many writes can occur before a read, all overwriting the previous.

A reader can asynchronously wait for a write, requiring the write to occur *during* the lifetime of the wait future, or immediately resolve from previous writes (up to the user).

That's it, thanks!