### PR TITLE
updated esp32c3 dependency to version 0.22.0

### DIFF
--- a/examples/esp32c3/Cargo.lock
+++ b/examples/esp32c3/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "esp-riscv-rt",
  "esp32",
  "esp32c2",
- "esp32c3",
+ "esp32c3 0.21.0",
  "esp32c6",
  "esp32h2",
  "esp32p4",
@@ -292,7 +292,7 @@ dependencies = [
  "esp-backtrace",
  "esp-hal",
  "esp-println",
- "esp32c3",
+ "esp32c3 0.22.0",
  "rtic",
 ]
 
@@ -311,6 +311,16 @@ name = "esp32c3"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a7ee710c1e4f16b5e840cdfec3f4e7642b7517a877c5c4b7e1cafa9a14117c5"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c3"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c22d8c27e7d675ef79db212b9e41df80aef6db1a5c819e4e726735f64ee0700"
 dependencies = [
  "critical-section",
  "vcell",
@@ -604,7 +614,7 @@ dependencies = [
  "atomic-polyfill",
  "bare-metal",
  "critical-section",
- "esp32c3",
+ "esp32c3 0.22.0",
  "riscv",
  "rtic-core",
  "rtic-macros",

--- a/examples/esp32c3/Cargo.toml
+++ b/examples/esp32c3/Cargo.toml
@@ -16,7 +16,7 @@ esp-backtrace = { version = "0.11.0", features = [
     "println",
 ] }
 
-esp32c3 = {version = "0.21.0", features = ["critical-section"]}
+esp32c3 = {version = "0.22.0", features = ["critical-section"]}
 esp-println = { version = "0.9.0", features = ["esp32c3", "uart"] }
 
 [features]

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Updated esp32c3 dependency to v0.22.0
 - Use `riscv-slic` from `crates.io`
 - Remove unused dependency `rtic-monotonics`
 

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -26,7 +26,7 @@ name = "rtic"
 
 [dependencies]
 riscv-slic = { version = "0.1.1", optional = true }
-esp32c3 = { version = "0.21.0", optional = true }
+esp32c3 = { version = "0.22.0", optional = true }
 riscv = { version = "0.11.0", optional = true }
 cortex-m = { version = "0.7.0", optional = true }
 bare-metal = "1.0.0"


### PR DESCRIPTION
This PR updates RTIC esp32c3 dependency to version 0.22.0 as well as version used for the corresponding example