### PR TITLE
Improve error output for prios > dispatchers

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Changed
+
+- Improve error output for prios > dispatchers
+
 ## [v2.1.0] - 2024-02-27
 
 ### Added


### PR DESCRIPTION
I ran into this `UNREACHABLE` while porting RTIC for an experimental RISC-V platform. I decided to improve the error for others. Platform-specific analysis may catch this as well but I would've found this implementation helpful, were it to exist prior to my port.