### PR TITLE
ExampleCheck platform and AppArgs backend never read

### DIFF
--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -70,6 +70,7 @@ pub struct AppArgs {
     pub dispatchers: Dispatchers,
 
     /// Backend-specific arguments
+    #[allow(dead_code)]
     pub backend: Option<BackendArgs>,
 }
 

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -12,10 +12,15 @@ enum Store<T> {
 }
 
 /// A "latest only" value store with unlimited writers and async waiting.
-#[derive(Default)]
 pub struct Signal<T: Copy> {
     waker: CriticalSectionWakerRegistration,
     store: UnsafeCell<Store<T>>,
+}
+
+impl<T: Copy> Default for Signal<T> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 unsafe impl<T: Copy> Send for Signal<T> {}

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -12,6 +12,7 @@ enum Store<T> {
 }
 
 /// A "latest only" value store with unlimited writers and async waiting.
+#[derive(Default)]
 pub struct Signal<T: Copy> {
     waker: CriticalSectionWakerRegistration,
     store: UnsafeCell<Store<T>>,

--- a/xtask/src/cargo_command.rs
+++ b/xtask/src/cargo_command.rs
@@ -44,6 +44,7 @@ pub enum CargoCommand<'a> {
     },
     ExampleCheck {
         cargoarg: &'a Option<&'a str>,
+        #[allow(dead_code)]
         platform: Platforms, // to tell which platform. If None, it assumes lm3s6965
         example: &'a str,
         target: Option<Target<'a>>,


### PR DESCRIPTION
- **rtic-macros: handle backend flagged as unused**
- **xtasks: handle platform flagged as unused**
