### PR TITLE
Fix broken rtic-monotonic stm32 behavior

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
+### Fixed
+
+ - Fix logic errors in `stm32.rs`
+
 ## v2.0.1 - 2024-06-02
 
 ### Changed

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -240,8 +240,8 @@ macro_rules! make_timer {
                 $timer.dier().modify(|r| r.set_uie(true));
 
                 // Configure and enable half-period interrupt
-                $timer.ccr(2).write(|r| r.set_ccr(($bits::MAX - ($bits::MAX >> 1)).into()));
-                $timer.dier().modify(|r| r.set_ccie(2, true));
+                $timer.ccr(1).write(|r| r.set_ccr(($bits::MAX - ($bits::MAX >> 1)).into()));
+                $timer.dier().modify(|r| r.set_ccie(1, true));
 
                 // Trigger an update event to load the prescaler value to the clock.
                 $timer.egr().write(|r| r.set_ug(true));
@@ -309,8 +309,8 @@ macro_rules! make_timer {
                     assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
                 }
                 // Half period
-                if $timer.sr().read().ccif(2) {
-                    $timer.sr().modify(|r| r.set_ccif(2, false));
+                if $timer.sr().read().ccif(1) {
+                    $timer.sr().modify(|r| r.set_ccif(1, false));
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
                     assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
                 }

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -240,8 +240,8 @@ macro_rules! make_timer {
                 $timer.dier().modify(|r| r.set_uie(true));
 
                 // Configure and enable half-period interrupt
-                $timer.ccr(1).write(|r| r.set_ccr(($bits::MAX - ($bits::MAX >> 1)).into()));
-                $timer.dier().modify(|r| r.set_ccie(1, true));
+                $timer.ccr(0).write(|r| r.set_ccr(($bits::MAX - ($bits::MAX >> 1)).into()));
+                $timer.dier().modify(|r| r.set_ccie(0, true));
 
                 // Trigger an update event to load the prescaler value to the clock.
                 $timer.egr().write(|r| r.set_ug(true));
@@ -290,7 +290,7 @@ macro_rules! make_timer {
                     0
                 };
 
-                $timer.ccr(1).write(|r| r.set_ccr(val.into()));
+                $timer.ccr(0).write(|r| r.set_ccr(val.into()));
             }
 
             fn clear_compare_flag() {
@@ -309,8 +309,8 @@ macro_rules! make_timer {
                     assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
                 }
                 // Half period
-                if $timer.sr().read().ccif(1) {
-                    $timer.sr().modify(|r| r.set_ccif(1, false));
+                if $timer.sr().read().ccif(0) {
+                    $timer.sr().modify(|r| r.set_ccif(0, false));
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
                     assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
                 }

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -294,7 +294,7 @@ macro_rules! make_timer {
             }
 
             fn clear_compare_flag() {
-                $timer.sr().modify(|r| r.set_ccif(1, false));
+                // Do nothing, because the flags are cleared below in on_interrupt
             }
 
             fn pend_interrupt() {

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -301,14 +301,6 @@ macro_rules! make_timer {
                 cortex_m::peripheral::NVIC::pend(pac::Interrupt::$timer);
             }
 
-            fn enable_timer() {
-                $timer.dier().modify(|r| r.set_ccie(1, true));
-            }
-
-            fn disable_timer() {
-                $timer.dier().modify(|r| r.set_ccie(1, false));
-            }
-
             fn on_interrupt() {
                 // Full period
                 if $timer.sr().read().uif() {


### PR DESCRIPTION
This fixes #956, and also another seemingly longstanding bug where stm32 the monotonic timer would use compare unit 3, even when it didn't exist. 