### PR TITLE
Fix STM32 Monotonic for peripherals with only two Clock Compare modules

### DIFF
--- a/examples/stm32g030f6_periodic_prints/.cargo/config.toml
+++ b/examples/stm32g030f6_periodic_prints/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # TODO(2) replace `$CHIP` with your chip's name (see `probe-run --list-chips` output)
-runner = "probe-run --chip STM32G030F6Px"
+runner = "probe-rs run --chip STM32G030F6Px"
 rustflags = [
   "-C", "linker=flip-link",
   "-C", "link-arg=-Tlink.x",

--- a/examples/stm32g030f6_periodic_prints/Cargo.lock
+++ b/examples/stm32g030f6_periodic_prints/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "defmt"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3939552907426de152b3c2c6f51ed53f98f448babd26f28694c95f5906194595"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -86,15 +86,15 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bdc7a7b92ac413e19e95240e75d3a73a8d8e78aa24a594c22cbb4d44b4bbda"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-rtt"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609923761264dd99ed9c7d209718cda4631c5fe84668e0f0960124cbb844c49f"
+checksum = "bab697b3dbbc1750b7c8b821aa6f6e7f2480b47a99bc057a2ed7b170ebef0c51"
 dependencies = [
  "critical-section",
  "defmt",
@@ -188,15 +188,15 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -219,9 +219,9 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "panic-probe"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6fa5645ef5a760cd340eaa92af9c1ce131c8c09e7f8926d8a24b59d26652b9"
+checksum = "4047d9235d1423d66cc97da7d07eddb54d4f154d6c13805c6d0793956f4f25b0"
 dependencies = [
  "cortex-m",
  "defmt",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -271,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -321,12 +321,12 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "rtic-monotonics"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.51"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,22 +450,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/examples/stm32g030f6_periodic_prints/Cargo.toml
+++ b/examples/stm32g030f6_periodic_prints/Cargo.toml
@@ -9,22 +9,22 @@ version = "0.1.0"
 
 [dependencies.rtic]
 path = "../../rtic"
-version = "2.0.1"
+version = "2.1.1"
 features = ["thumbv6-backend"]
 
 [dependencies.rtic-monotonics]
 path = "../../rtic-monotonics"
-version = "2.0.0"
+version = "2.0.1"
 features = ["stm32g030f6", "stm32_tim3"]
 
 
 [dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
-defmt = "0.3.4"
-defmt-rtt = "0.4.0"
+defmt = "0.3.8"
+defmt-rtt = "0.4.1"
 fugit = "0.3.7"
-panic-probe = { version = "0.3.1", features = ["print-defmt"] }
+panic-probe = { version = "0.3.2", features = ["print-defmt"] }
 portable-atomic = { version = "1", features = ["unsafe-assume-single-core"] }
 
 stm32g0xx-hal = { version = "0.2.0", features = ["rt", "stm32g030"] }

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
+### Fixed
+
+- Fix `stm32` monotonic for timer peripherals with only two clock compare modules
+
 ## v2.0.1 - 2024-06-02
 
 ### Changed

--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -94,7 +94,7 @@ impl TimerQueueBackend for TimerBackend {
 
         // Since the timer may or may not overflow based on the requested compare val, we check
         // how many ticks are left.
-        // `wrapping_sup` takes care of the u64 integer overflow special case.
+        // `wrapping_sub` takes care of the u64 integer overflow special case.
         let val = if instant.wrapping_sub(now) <= MAX {
             instant & MAX
         } else {

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -282,7 +282,7 @@ macro_rules! make_timer {
                 let now = Self::now();
 
                 // Since the timer may or may not overflow based on the requested compare val, we check how many ticks are left.
-                // `wrapping_sup` takes care of the u64 integer overflow special case.
+                // `wrapping_sub` takes care of the u64 integer overflow special case.
                 let val = if instant.wrapping_sub(now) <= ($bits::MAX as u64) {
                     instant as $bits
                 } else {

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -240,8 +240,8 @@ macro_rules! make_timer {
                 $timer.dier().modify(|r| r.set_uie(true));
 
                 // Configure and enable half-period interrupt
-                $timer.ccr(2).write(|r| r.set_ccr(($bits::MAX - ($bits::MAX >> 1)).into()));
-                $timer.dier().modify(|r| r.set_ccie(2, true));
+                $timer.ccr(0).write(|r| r.set_ccr(($bits::MAX - ($bits::MAX >> 1)).into()));
+                $timer.dier().modify(|r| r.set_ccie(0, true));
 
                 // Trigger an update event to load the prescaler value to the clock.
                 $timer.egr().write(|r| r.set_ug(true));
@@ -317,8 +317,8 @@ macro_rules! make_timer {
                     assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
                 }
                 // Half period
-                if $timer.sr().read().ccif(2) {
-                    $timer.sr().modify(|r| r.set_ccif(2, false));
+                if $timer.sr().read().ccif(0) {
+                    $timer.sr().modify(|r| r.set_ccif(0, false));
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
                     assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
                 }


### PR DESCRIPTION
Fixes #956.
Replaces #958.

Rationale: Some timer peripherals seem to have only two clock compare modules. Therefore the half period interrupt does not fire and the monotonic sanity check triggers.

Solution: Use CC1 instead of CC3. This was more or less a typo anyway; we originally intended to use CC1 and CC2, we just ended up using CC2 and CC3 because we didn't realize that the enumeration starts with 0.

Review: @korken89 