### PR TITLE
Fix codegen emitting unqualified `Result`

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Fix codegen emitting unqualified `Result`
 - Improve error output for prios > dispatchers
 
 ## [v2.1.0] - 2024-02-27

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -168,7 +168,7 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
             /// Spawns the task directly
             #[allow(non_snake_case)]
             #[doc(hidden)]
-            pub fn #internal_spawn_ident(#(#input_args,)*) -> Result<(), #input_ty> {
+            pub fn #internal_spawn_ident(#(#input_args,)*) -> ::core::result::Result<(), #input_ty> {
                 // SAFETY: If `try_allocate` succeeds one must call `spawn`, which we do.
                 unsafe {
                     let exec = rtic::export::executor::AsyncTaskExecutor::#from_ptr_n_args(#name, &#exec_name);


### PR DESCRIPTION
Closes https://github.com/rtic-rs/rtic/issues/965