### PR TITLE
Fix for system_monotonic macro with 1 argument

### DIFF
--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -144,7 +144,7 @@ impl TimerQueueBackend for SystickBackend {
 #[macro_export]
 macro_rules! systick_monotonic {
     ($name:ident) => {
-        $crate::systick_monotonic($name, 1_000);
+        $crate::systick_monotonic!($name, 1_000);
     };
     ($name:ident, $tick_rate_hz:expr) => {
         /// A `Monotonic` based on SysTick.


### PR DESCRIPTION
I think this is missing, at least I get an error when I try to use the macro is it is now.