### PR TITLE
Replace proc-macro-error with proc-macro-error2

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+- Replace `proc-macro-error` with `proc-macro-error2`
+
 ### Changed
 
 - Fix codegen emitting unqualified `Result`

--- a/rtic-macros/Cargo.toml
+++ b/rtic-macros/Cargo.toml
@@ -37,14 +37,14 @@ riscv-esp32c3 = []
 # riscv-clic = []
 # riscv-ch32 = []
 riscv-slic = []
- 
+
 # backend API test
 test-template = []
 
 [dependencies]
 indexmap = "2.0.0"
 proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
+proc-macro-error2 = "2.0"
 quote = "1.0.23"
 syn = { version = "2.0.48", features = ["extra-traits", "full"] }
 


### PR DESCRIPTION
`proc-macro-error` depends on `syn` 1.0 and is [no longer maintained](https://vulert.com/vuln-db/crates-io-proc-macro-error-150139). This PR replaces it with the drop-in replacement [`proc-macro-error2`](https://crates.io/crates/proc-macro-error2).