### PR TITLE
[monotonics] Fix STM32 read-modify-write race condition

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -15,6 +15,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Update `esp32c3` dependency
 
+### Fixed
+
+- Race condition that caused missed interrupts on STM32 timers
+
 ## v2.0.2 - 2024-07-05
 
 ### Added

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -17,7 +17,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
-- Race condition that caused missed interrupts on STM32 timers
+- STM32: Make initialization more deterministic
+- STM32: Fix race condition that caused missed interrupts
 
 ## v2.0.2 - 2024-07-05
 

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -246,11 +246,16 @@ macro_rules! make_timer {
                 // Trigger an update event to load the prescaler value to the clock.
                 $timer.egr().write(|r| r.set_ug(true));
 
+                // Clear timer value so it is known that we are at the first half period
+                $timer.cnt().write(|r| r.set_cnt(1));
+
                 // The above line raises an update event which will indicate that the timer is already finished.
                 // Since this is not the case, it should be cleared.
                 $timer.sr().write(|r| {
                     r.0 = !0;
                     r.set_uif(false);
+                    r.set_ccif(0, false);
+                    r.set_ccif(1, false);
                 });
 
                 $tq.initialize(Self {});

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -249,8 +249,8 @@ macro_rules! make_timer {
                 // Clear timer value so it is known that we are at the first half period
                 $timer.cnt().write(|r| r.set_cnt(1));
 
-                // The above line raises an update event which will indicate that the timer is already finished.
-                // Since this is not the case, it should be cleared.
+                // Triggering the update event might have raised overflow interrupts.
+                // Clear them to return to a known state.
                 $timer.sr().write(|r| {
                     r.0 = !0;
                     r.set_uif(false);

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -248,7 +248,10 @@ macro_rules! make_timer {
 
                 // The above line raises an update event which will indicate that the timer is already finished.
                 // Since this is not the case, it should be cleared.
-                $timer.sr().modify(|r| r.set_uif(false));
+                $timer.sr().write(|r| {
+                    r.0 = !0;
+                    r.set_uif(false);
+                });
 
                 $tq.initialize(Self {});
                 $overflow.store(0, Ordering::SeqCst);
@@ -294,7 +297,10 @@ macro_rules! make_timer {
             }
 
             fn clear_compare_flag() {
-                $timer.sr().modify(|r| r.set_ccif(1, false));
+                $timer.sr().write(|r| {
+                    r.0 = !0;
+                    r.set_ccif(1, false);
+                });
             }
 
             fn pend_interrupt() {
@@ -312,13 +318,19 @@ macro_rules! make_timer {
             fn on_interrupt() {
                 // Full period
                 if $timer.sr().read().uif() {
-                    $timer.sr().modify(|r| r.set_uif(false));
+                    $timer.sr().write(|r| {
+                        r.0 = !0;
+                        r.set_uif(false);
+                    });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
                     assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
                 }
                 // Half period
                 if $timer.sr().read().ccif(0) {
-                    $timer.sr().modify(|r| r.set_ccif(0, false));
+                    $timer.sr().write(|r| {
+                        r.0 = !0;
+                        r.set_ccif(0, false);
+                    });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
                     assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
                 }


### PR DESCRIPTION
The `SR` register for STM32 clears when writing a zero to a bit. Therefore, all registers that should not be cleared need to be `1`.

`modify` here caused a read-modify-write error that could clear unrelated flags.

Related: https://github.com/libopencm3/libopencm3/issues/392
Fixes: https://github.com/rtic-rs/rtic/issues/956