### PR TITLE
Signal ergo minor fixes

### DIFF
--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -41,7 +41,7 @@ impl<T: Copy> Signal<T> {
     }
 }
 
-/// Fascilitates the writing of values to a Signal.
+/// Facilitates the writing of values to a Signal.
 #[derive(Clone)]
 pub struct SignalWriter<'a, T: Copy> {
     parent: &'a Signal<T>,
@@ -69,7 +69,7 @@ impl<'a, T: Copy> SignalWriter<'a, T> {
     }
 }
 
-/// Fascilitates the async reading of values from the Signal.
+/// Facilitates the async reading of values from the Signal.
 pub struct SignalReader<'a, T: Copy> {
     parent: &'a Signal<T>,
 }

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -17,6 +17,18 @@ pub struct Signal<T: Copy> {
     store: UnsafeCell<Store<T>>,
 }
 
+impl<T> core::fmt::Debug for Signal<T>
+where
+    T: core::marker::Copy,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_fmt(format_args!(
+            "Signal<{}>{{ .. }}",
+            core::any::type_name::<T>()
+        ))
+    }
+}
+
 impl<T: Copy> Default for Signal<T> {
     fn default() -> Self {
         Self::new()
@@ -47,6 +59,18 @@ pub struct SignalWriter<'a, T: Copy> {
     parent: &'a Signal<T>,
 }
 
+impl<T> core::fmt::Debug for SignalWriter<'_, T>
+where
+    T: core::marker::Copy,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_fmt(format_args!(
+            "SignalWriter<{}>{{ .. }}",
+            core::any::type_name::<T>()
+        ))
+    }
+}
+
 impl<'a, T: Copy> SignalWriter<'a, T> {
     /// Write a raw Store value to the Signal.
     fn write_inner(&mut self, value: Store<T>) {
@@ -72,6 +96,18 @@ impl<'a, T: Copy> SignalWriter<'a, T> {
 /// Facilitates the async reading of values from the Signal.
 pub struct SignalReader<'a, T: Copy> {
     parent: &'a Signal<T>,
+}
+
+impl<T> core::fmt::Debug for SignalReader<'_, T>
+where
+    T: core::marker::Copy,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_fmt(format_args!(
+            "SignalReader<{}>{{ .. }}",
+            core::any::type_name::<T>()
+        ))
+    }
 }
 
 impl<'a, T: Copy> SignalReader<'a, T> {


### PR DESCRIPTION
This fixes a couple of docs typos and derives Debug for Signal, SignalReader, and SignalWriter (and CriticalSectionWakerRegistration).

Having Debug available enables e.g. `my_task::spawn(my_signal_reader).unwrap();`