### PR TITLE
Do not limit async priority with `NVIC_PRIO_BITS` when targeting ESP32-C3

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -17,6 +17,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Fixed
 
 - Fix interrupt handlers when targeting esp32c3 and using latest version of esp-hal
+- Do not limit async priority with `NVIC_PRIO_BITS` when targeting esp32c3
 
 ## [v2.1.0] - 2024-02-27
 

--- a/rtic-macros/src/codegen/bindings/esp32c3.rs
+++ b/rtic-macros/src/codegen/bindings/esp32c3.rs
@@ -211,9 +211,7 @@ mod esp32c3 {
         let max = if let Some(max) = analysis.max_async_prio {
             quote!(#max)
         } else {
-            // No limit
-            let device = &app.args.device;
-            quote!(1 << #device::NVIC_PRIO_BITS)
+            quote!(u8::MAX) // No limit
         };
 
         vec![quote!(


### PR DESCRIPTION
Since RISC-V devices do not have an NVIC, we set the `nvicPrioBits` field in our SVDs simply to 0. As such, this value should not be used to determine the maximum async priority, and I have aligned the codegen bindings for this target with the `riscv_slic` version.