### PR TITLE
Add standalone waker constructor for executor and expose it

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Added
+
+- Added `waker` getter to software tasks
+
 ## [v2.1.3] - 2025-06-08
 
 ### Changed 

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -192,7 +192,7 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
             #[allow(non_snake_case)]
             #[doc(hidden)]
             pub fn #internal_waker_ident() -> ::core::task::Waker {
-                // SAFETY: If `try_allocate` succeeds one must call `spawn`, which we do.
+                // SAFETY: #exec_name is a valid pointer to an executor.
                 unsafe {
                     let exec = rtic::export::executor::AsyncTaskExecutor::#from_ptr_n_args(#name, &#exec_name);
                     exec.waker(|| {

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -20,6 +20,10 @@ Example:
 
 ## [Unreleased]
 
+### Added
+
+- Added public `waker` constructor to the executor.
+
 ## [v2.1.3] - 2025-06-08
 
 ### Fixed

--- a/rtic/src/export/executor.rs
+++ b/rtic/src/export/executor.rs
@@ -192,11 +192,16 @@ impl<F: Future + 'static> AsyncTaskExecutor<F> {
         self.set_pending();
     }
 
+    #[inline(always)]
+    pub const fn waker(&self, wake: fn()) -> Waker {
+        unsafe { Waker::from_raw(RawWaker::new(wake as *const (), &WAKER_VTABLE)) }
+    }
+
     /// Poll the future in the executor.
     #[inline(always)]
     pub fn poll(&self, wake: fn()) {
         if self.is_running() && self.check_and_clear_pending() {
-            let waker = unsafe { Waker::from_raw(RawWaker::new(wake as *const (), &WAKER_VTABLE)) };
+            let waker = self.waker(wake);
             let mut cx = Context::from_waker(&waker);
             let future = unsafe { Pin::new_unchecked(&mut *(self.task.get() as *mut F)) };
 


### PR DESCRIPTION
Currently we can spawn a task with `task::spawn()`, but there is no way to get a waker. This PR adds const function `task::waker()`, that returns a waker that will wake that task. 

My use case for this is smoltcp, they expose a lot of functions like that one: [Socket::register_waker](https://docs.rs/smoltcp/latest/smoltcp/socket/dhcpv4/struct.Socket.html#method.register_waker)