### PR TITLE
Fix #780: rtic-sync panic

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -17,6 +17,11 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - `defmt v0.3` derives added and forwarded to `embedded-hal(-x)` crates.
 - signal structure
 
+### Fixed
+- Fix [#780]
+
+[#780]: https://github.com/rtic-rs/rtic/issues/780
+
 ## v1.2.0 - 2024-01-10
 
 ### Changed

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -432,16 +432,16 @@ impl<T, const N: usize> Receiver<'_, T, N> {
             critical_section::with(|cs| {
                 assert!(!self.0.access(cs).freeq.is_full());
                 unsafe { self.0.access(cs).freeq.push_back_unchecked(rs) }
-            });
 
-            fence(Ordering::SeqCst);
+                fence(Ordering::SeqCst);
 
-            // If someone is waiting in the WaiterQueue, wake the first one up.
-            if let Some(wait_head) = self.0.wait_queue.pop() {
-                wait_head.wake();
-            }
+                // If someone is waiting in the WaiterQueue, wake the first one up.
+                if let Some(wait_head) = self.0.wait_queue.pop() {
+                    wait_head.wake();
+                }
 
-            Ok(r)
+                Ok(r)
+            })
         } else if self.is_closed() {
             Err(ReceiveError::NoSender)
         } else {


### PR DESCRIPTION
An explicit PR that fixes the bug but sidesteps the addition of `loom` to avoid the side effects it may introduce.

Fixes #780

Extracts the relevant bugfix part from #1027

A description of the path leading to the bug, which also proves that the fix actually solves the problem:

1. `try_recv` pushes into `freeq`.
2. Before popping `wait_queue`, an interrupt occurs.
3. `send` no. 1 eats up the `freeq` slot.
4. `send` no. 2 is called, pushes its link to `wait_queue` and goes to sleep (because `freeq` is now empty)
5. Control returns to `try_recv`, which pops `wait_queue` (from the newly waiting `send` call) _without_ touching the free queue.
6. `send` is awoken at some point. Its link is popped, but the `freeq` is empty.