### PR TITLE
rtic-sync: explicitly send an awoken Sender the slot it can use to avoid TOCTU bugs

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,6 +7,9 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## [Unreleased]
 
+### Fixed
+- Improve handling of free slots for `send` by explicitly writing the free slot to the awoken future.
+
 ## v1.3.1 - 2025-03-12
 
 ### Fixed

--- a/rtic-sync/Cargo.toml
+++ b/rtic-sync/Cargo.toml
@@ -29,6 +29,7 @@ embedded-hal-bus = { version = "0.2.0", features = ["async"] }
 defmt-03 = { package = "defmt", version = "0.3", optional = true }
 
 [dev-dependencies]
+cassette = "0.3.0"
 static_cell = "2.1.0"
 tokio = { version = "1", features = ["rt", "macros", "time"] }
 

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -363,7 +363,8 @@ impl<T, const N: usize> Sender<'_, T, N> {
                 }
 
                 // SAFETY: `free_slot_ptr` is valid for writes, as `free_slot_ptr` is still alive.
-                let slot = unsafe { free_slot_ptr.replace(None, cs) };
+                let slot = unsafe { free_slot_ptr.replace(None, cs) }
+                    .or_else(|| self.0.access(cs).freeq.pop_back());
 
                 if let Some(slot) = slot {
                     Poll::Ready(Ok(slot))

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -332,6 +332,10 @@ impl<T, const N: usize> Sender<'_, T, N> {
         let idx = poll_fn(|cx| {
             //  Do all this in one critical section, else there can be race conditions
             critical_section::with(|cs| {
+                if self.is_closed() {
+                    return Poll::Ready(Err(()));
+                }
+
                 let wq_empty = self.0.wait_queue.is_empty();
                 let freeq_empty = self.0.access(cs).freeq.is_empty();
 


### PR DESCRIPTION
This PR ensures that `send` behaves consistently in the face of concurrent sending and receiving to and from a channel.

Since we now no longer rely on a slot being available in `freeq`, but rather on direct message passing by the `try_recv` function that cannot be re-ordered or interrupted in the same way as before, it should prevent all of the TOCTU problems we have observed when using `send` so far.

This also makes the send queue fairer: a `try_send` and `send` can now no longer "steal" a `freeq` slot from a longer-waiting `send` future.

The unsafe parts of this function are a bit more scary, though.