### PR TITLE
Don't force `Signal` import when using `make_signal` macro

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,6 +7,9 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## [Unreleased]
 
+- Don't force `Signal` import when using `make_signal` macro
+- Update `make_signal`'s documentation to match `make_channel`'s 
+
 ## v1.3.2 - 2025-03-16
 
 ### Fixed

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -161,7 +161,7 @@ impl<T: Copy> SignalReader<'_, T> {
 #[macro_export]
 macro_rules! make_signal {
     ( $T:ty ) => {{
-        static SIGNAL: Signal<$T> = Signal::new();
+        static SIGNAL: $crate::signal::Signal<$T> = $crate::signal::Signal::new();
 
         SIGNAL.split()
     }};

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -157,7 +157,7 @@ impl<T: Copy> SignalReader<'_, T> {
     }
 }
 
-/// Convenience macro for creating a Signal.
+/// Creates a split signal with `'static` lifetime.
 #[macro_export]
 macro_rules! make_signal {
     ( $T:ty ) => {{


### PR DESCRIPTION
The current source code of `make_signal` forces one to `use rtic_sync::signal::Signal;`.
This commit fixes that.

Also, I updated the documentation to mention that the created signal has a `'static` lifetime, just like for the `make_channel` macro.