### PR TITLE
rtic-sync: deal with dropping & re-splitting channels.

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -17,7 +17,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Changed
 
+- Actually drop items left over in `Channel` on drop of `Channel`.
+- Allow for `split()`-ing a channel more than once without immediately panicking.
 - Add `loom` support.
+- Avoid a critical section when a `send`-link is popped and when returning `free_slot`.
 - Don't force `Signal` import when using `make_signal` macro
 - Update `make_signal`'s documentation to match `make_channel`'s
 

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -17,7 +17,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Changed
 
-- Actually drop items left over in `Channel` on drop of `Channel`.
+- Actually drop items left over in `Channel` on drop of `Receiver`.
 - Allow for `split()`-ing a channel more than once without immediately panicking.
 - Add `loom` support.
 - Avoid a critical section when a `send`-link is popped and when returning `free_slot`.

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -128,6 +128,9 @@ impl<T, const N: usize> Channel<T, N> {
                     core::ptr::read(ptr)
                 };
 
+                // NOTE: do not `return_free_slot`, as we have mutable
+                // access to this `Channel` and no `Receiver` or `Sender`
+                // exist.
                 assert!(!self.inner.freeq.as_mut().is_full());
                 unsafe {
                     // SAFETY: `freeq` is not ful.


### PR DESCRIPTION
Currently `split`-ing a channel is technically allowed, but there is no non-`panic` way of actually doing so.

Currently it will either `panic` if `freeq` is full (and `readyq` is empty), or succesfully re-split and always produce `Err(NoReceiver)` when sending, and/or `panic` eventually when returning a free slot while `recv`-ing. 

Additionally, items in the ready queue are never dropped if the channel is dropped.

This is not a particularly often-used use-case, but that doesn't mean we cannot try fixing it :)

An alternative approach is to just have a `split: bool` in the `Channel` and always `panic` if that bool is already set, or always calling `Channel::clear` when `split`-ing.

To see concrete use-cases that this PR fixes, please check out the introduced tests.