### PR TITLE
rtic-sync: No need for c-s to check if link is in wait queue if link is popped

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,8 +7,9 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## [Unreleased]
 
+- Avoid a critical section when a `send`-link is popped and when returning `free_slot`.
 - Don't force `Signal` import when using `make_signal` macro
-- Update `make_signal`'s documentation to match `make_channel`'s 
+- Update `make_signal`'s documentation to match `make_channel`'s
 
 ## v1.3.2 - 2025-03-16
 


### PR DESCRIPTION
Minor improvement: if we insert our link into the wait queue, we always take a critical section (in the `OnDrop`) to ensure that it is no longer in the list on drop. 

However, if our link is popped, we know for a fact that it is not in the list. `take()`-ing it in the block that gets us into that state saves us an unnecessary critical section, which is probably the 2nd-most common scenario (the 1st being finding a free slot immediately).

Additionally, we take a critical-section to check whether we still have an entry in our `SlotPtr`. However, once we are certain that our `link` is removed from the list, we have exclusive access to it again: hence, we can skip that critical section too, on the happy path.