### PR TITLE
Simplify CI & expand coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,33 +69,32 @@ jobs:
   # Compilation check (hifive1) TODO
   # checkhifive1:
 
-  # Clippy (lm3s6965)
-  clippylm3s6965:
-    name: clippy (lm3s6965)
+  # Clippy
+  # TODO: clippy hifive1, esp32-c3
+  clippy:
+    name: clippy
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        backend:
-          - thumbv7
-          - thumbv6
-          - thumbv8-base
-          - thumbv8-main
-        toolchain:
-          - stable
+        input:
+          - backend: thumbv7
+            rustup-target: thumbv7m-none-eabi
+
+          - backend: thumbv6
+            rustup-target: thumbv6m-none-eabi
+
+          - backend: thumbv8-base
+            rustup-target: thumbv8m.base-none-eabi
+
+          - backend: thumbv8-main
+            rustup-target: thumbv8m.main-none-eabi
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup override set ${{ matrix.toolchain }}
-
-      - name: Configure Rust target (v6, v7, v8.b v8.m)
-        run: |
-          rustup target add thumbv7m-none-eabi
-          rustup target add thumbv6m-none-eabi
-          rustup target add thumbv8m.base-none-eabi
-          rustup target add thumbv8m.main-none-eabi
+      - name: Configure Rust target
+        run:  rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Add Rust component clippy
         run: rustup component add clippy
@@ -103,10 +102,7 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
-      - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.backend }} clippy
-
-  # Clippy (hifive1) TODO
-  # clippyhifive1:
+      - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.input.backend }} clippy
 
   # Verify all examples, checks
   checkexamples:
@@ -749,8 +745,7 @@ jobs:
       - formatcheck
       - checklm3s6965
       # - checkhifive1 # TODO
-      - clippylm3s6965
-      # - clippyhifive1 # TODO
+      - clippy
       - checkexamples
       - testexamples
       - tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,25 +152,18 @@ jobs:
           - backend: riscv32-imc-clint
             platform: hifive1
             rustup-target: riscv32imc-unknown-none-elf
-            custom-toolchain: rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf && rustup override set nightly
 
           - backend: riscv32-imc-mecall
             platform: hifive1
             rustup-target: riscv32imc-unknown-none-elf
-            custom-toolchain: rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf && rustup override set nightly
 
           - backend: riscv-esp32-c3
             platform: esp32-c3
             rustup-target: riscv32imc-unknown-none-elf
-            custom-toolchain: rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf && rustup override set nightly
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install optional custom toolchain
-        if: matrix.input.custom-toolchain
-        run: ${{ matrix.input.custom-toolchain }}
 
       - name: Configure Rust target
         run: rustup target add ${{ matrix.input.rustup-target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
         run:  cargo xtask --verbose fmt -c
 
   # Compilation check
-  # TODO: check esp32-c3
   check:
     name: check
     runs-on: ubuntu-22.04
@@ -63,6 +62,10 @@ jobs:
 
           - backend: riscv32-imc-mecall
             platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+
+          - backend: riscv-esp32-c3
+            platform: esp32-c3
             rustup-target: riscv32imc-unknown-none-elf
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.input.backend }} check
 
   # Clippy
-  # TODO: clippy hifive1, esp32-c3
+  # TODO: clippy esp32-c3
   clippy:
     name: clippy
     runs-on: ubuntu-22.04
@@ -73,16 +73,28 @@ jobs:
       matrix:
         input:
           - backend: thumbv7
+            platform: lm3s6965
             rustup-target: thumbv7m-none-eabi
 
           - backend: thumbv6
+            platform: lm3s6965
             rustup-target: thumbv6m-none-eabi
 
           - backend: thumbv8-base
+            platform: lm3s6965
             rustup-target: thumbv8m.base-none-eabi
 
           - backend: thumbv8-main
+            platform: lm3s6965
             rustup-target: thumbv8m.main-none-eabi
+
+          - backend: riscv32-imc-clint
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+
+          - backend: riscv32-imc-mecall
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
 
     steps:
       - name: Checkout
@@ -97,7 +109,7 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
-      - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.input.backend }} clippy
+      - run: cargo xtask --deny-warnings --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} clippy
 
   # Verify all examples, checks
   checkexamples:
@@ -184,7 +196,7 @@ jobs:
 
       - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
         name: Download QEMU
-        run: wget "${{ env.QEMU_URL }}" 
+        run: wget "${{ env.QEMU_URL }}"
 
       - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
         name: Extract QEMU

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,15 @@ jobs:
       - name: cargo xtask fmt
         run:  cargo xtask --verbose fmt -c
 
-  # Compilation check
-  check:
-    name: check
-    runs-on: ubuntu-22.04
+  # Verify all examples, checks
+  check-clippy:
+    uses: ./.github/workflows/clippy-check-example.yml
+    with:
+      backend: ${{ matrix.input.backend }}
+      platform: ${{ matrix.input.platform }}
+      rustup-target: ${{ matrix.input.rustup-target }}
+      example-args: ${{ matrix.input.example-args }}
+
     strategy:
       matrix:
         input:
@@ -51,6 +56,7 @@ jobs:
           - backend: thumbv8-base
             platform: lm3s6965
             rustup-target: thumbv8m.base-none-eabi
+            example-args: --exampleexclude pool
 
           - backend: thumbv8-main
             platform: lm3s6965
@@ -67,20 +73,9 @@ jobs:
           - backend: riscv-esp32-c3
             platform: esp32-c3
             rustup-target: riscv32imc-unknown-none-elf
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure Rust target ${{ matrix.input.rustup-target }}
-        run: rustup target add ${{ matrix.input.rustup-target }}
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - run: cargo xtask --deny-warnings --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} check
 
   # Clippy
-  # TODO: clippy esp32-c3
+  # TODO: put in clippy-check-example once esp32-c3 clippy is fixed
   clippy:
     name: clippy
     runs-on: ubuntu-22.04
@@ -125,59 +120,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - run: cargo xtask --deny-warnings --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} clippy
-
-  # Verify all examples, checks
-  checkexamples:
-    name: check examples
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        input:
-          - backend: thumbv7
-            platform: lm3s6965
-            rustup-target: thumbv7m-none-eabi
-
-          - backend: thumbv6
-            platform: lm3s6965
-            rustup-target: thumbv6m-none-eabi
-
-          - backend: thumbv8-base
-            platform: lm3s6965
-            rustup-target: thumbv8m.base-none-eabi
-
-          - backend: thumbv8-main
-            platform: lm3s6965
-            rustup-target: thumbv8m.main-none-eabi
-
-          - backend: riscv32-imc-clint
-            platform: hifive1
-            rustup-target: riscv32imc-unknown-none-elf
-
-          - backend: riscv32-imc-mecall
-            platform: hifive1
-            rustup-target: riscv32imc-unknown-none-elf
-
-          - backend: riscv-esp32-c3
-            platform: esp32-c3
-            rustup-target: riscv32imc-unknown-none-elf
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure Rust target ${{ matrix.input.rustup-target }}
-        run: rustup target add ${{ matrix.input.rustup-target }}
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Check the examples
-        if: ${{ matrix.input.backend == 'thumbv8-base' }}
-        run: cargo xtask --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} --exampleexclude pool example-check
-
-      - name: Check the examples
-        if: ${{ matrix.input.backend != 'thumbv8-base' }}
-        run: cargo xtask --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} example-check
 
   buildqemu:
     name: Get modern QEMU, build and store
@@ -763,9 +705,7 @@ jobs:
     if: github.event_name == 'push' && success()
     needs:
       - formatcheck
-      - check
-      - clippy
-      - checkexamples
+      - check-clippy
       - testexamples
       - tests
       - docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,102 +108,65 @@ jobs:
   # Clippy (hifive1) TODO
   # clippyhifive1:
 
-  # Platform lm3s6965: verify all examples, checks
-  checkexampleslm3s6965:
-    name: check examples (lm3s6965)
+  # Verify all examples, checks
+  checkexamples:
+    name: check examples
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        backend:
-          - thumbv7
-          - thumbv6
-          - thumbv8-base
-          - thumbv8-main
-        toolchain:
-          - stable
+        input:
+          - backend: thumbv7
+            platform: lm3s6965
+            rustup-target: thumbv7m-none-eabi
+
+          - backend: thumbv6
+            platform: lm3s6965
+            rustup-target: thumbv6m-none-eabi
+
+          - backend: thumbv8-base
+            platform: lm3s6965
+            rustup-target: thumbv8m.base-none-eabi
+
+          - backend: thumbv8-main
+            platform: lm3s6965
+            rustup-target: thumbv8m.main-none-eabi
+
+          - backend: riscv32-imc-clint
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+            custom-toolchain: rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf && rustup override set nightly
+
+          - backend: riscv32-imc-mecall
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+            custom-toolchain: rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf && rustup override set nightly
+
+          - backend: riscv-esp32-c3
+            platform: esp32-c3
+            rustup-target: riscv32imc-unknown-none-elf
+            custom-toolchain: rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf && rustup override set nightly
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup override set ${{ matrix.toolchain }}
-
-      - name: Configure Rust target (v6, v7, v8.b v8.m)
-        run: |
-          rustup target add thumbv7m-none-eabi
-          rustup target add thumbv6m-none-eabi
-          rustup target add thumbv8m.base-none-eabi
-          rustup target add thumbv8m.main-none-eabi
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Check the examples
-        if: ${{ matrix.backend == 'thumbv8-base' }}
-        run: cargo xtask --platform lm3s6965 --backend ${{ matrix.backend }} --exampleexclude pool example-check
-
-      - name: Check the examples
-        if: ${{ matrix.backend != 'thumbv8-base' }}
-        run: cargo xtask --platform lm3s6965 --backend ${{ matrix.backend }} example-check
-  
-  # Platform hifive1: verify all examples, checks
-  checkexampleshifive1:
-    name: check examples (hifive1)
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        backend:
-          - riscv32-imc-clint
-          - riscv32-imc-mecall
-        toolchain:
-          - stable
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup override set ${{ matrix.toolchain }}
+      - name: Install optional custom toolchain
+        if: matrix.input.custom-toolchain
+        run: ${{ matrix.input.custom-toolchain }}
 
       - name: Configure Rust target
-        run: |
-          rustup target add riscv32imc-unknown-none-elf
+        run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
-      
+
       - name: Check the examples
-        run: cargo xtask --platform hifive1 --backend ${{ matrix.backend }} example-check
+        if: ${{ matrix.input.backend == 'thumbv8-base' }}
+        run: cargo xtask --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} --exampleexclude pool example-check
 
-  # Platform esp32c3: verify all examples, checks
-  checkexamplesesp32c3:
-    name: check examples (esp32c3)
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        backend:
-          - riscv-esp32-c3
-        toolchain:
-          - nightly
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup toolchain install nightly-2023-11-14 --component rust-src --target riscv32imc-unknown-none-elf
-
-      - name: Configure Rust target
-        run: |
-          rustup target add riscv32imc-unknown-none-elf
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-      
       - name: Check the examples
-        run: cargo xtask --platform esp32-c3 --backend ${{ matrix.backend }} example-check
-
+        if: ${{ matrix.input.backend != 'thumbv8-base' }}
+        run: cargo xtask --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} example-check
 
   buildqemu:
     name: Get modern QEMU, build and store
@@ -888,9 +851,7 @@ jobs:
       # - checkhifive1 # TODO
       - clippylm3s6965
       # - clippyhifive1 # TODO
-      - checkexampleslm3s6965
-      - checkexampleshifive1
-      - checkexamplesesp32c3
+      - checkexamples
       - testexampleslm3s6965
       - testexampleshifive1
       - testexamplesesp32c3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -326,7 +326,12 @@ jobs:
           name: qemu
 
       - name: Extract QEMU into local path
+        if: ${{ matrix.input.platform != 'esp32-c3' }}
         run: tar -xf qemu.tar -C /usr/local/bin
+
+      - name: Extract ESP32 QEMU into local path
+        if: ${{ matrix.input.platform == 'esp32-c3' }}
+        run: sudo tar --strip-components=1 -xf qemu.tar -C /usr/local/ esp32/
 
       - name: Check which QEMU is used
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           cd qemu-${{ env.QEMU_VERSION }}
           ninja -C build
-          
+
       - name: Download ESP32 QEMU
         run: wget "${{ env.QEMU_ESP_URL }}" --output-document=${{ env.QEMU_ESP}}.tar.xz
 
@@ -230,150 +230,51 @@ jobs:
           name: qemu
           path: qemu.tar
 
-  # Platform lm3s6965: verify the example output with run-pass tests
-  testexampleslm3s6965:
-    name: QEMU run (lm3s6965)
+  # Verify the example output with run-pass tests
+  testexamples:
+    name: QEMU run
     needs: buildqemu
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        backend:
-          - thumbv7
-          - thumbv6
-        toolchain:
-          - stable
+        input:
+          - backend: thumbv7
+            platform: lm3s6965
+            rustup-target: thumbv7m-none-eabi
+            qemu-system: arm
+
+          - backend: thumbv6
+            platform: lm3s6965
+            rustup-target: thumbv6m-none-eabi
+            qemu-system: arm
+
+          - backend: riscv32-imc-clint
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+            qemu-system: riscv32
+
+          - backend: riscv32-imc-mecall
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+            qemu-system: riscv32
+
+          - backend: riscv-esp32-c3
+            platform: esp32-c3
+            rustup-target: riscv32imc-unknown-none-elf
+            qemu-system: riscv32
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup set profile minimal
-          rustup override set ${{ matrix.toolchain }}
-
-      - name: Configure Rust target (v6, v7)
-        run: |
-          rustup target add thumbv7m-none-eabi
-          rustup target add thumbv6m-none-eabi
-
-      - name: Add Rust component llvm-tools-preview
-        run: rustup component add llvm-tools-preview
-
-      # Use precompiled binutils
-      - name: Install cargo-binutils
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-binutils
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install QEMU to get dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y qemu-system-arm
-
-      - name: Download built QEMU
-        uses: actions/download-artifact@v4
-        with:
-          name: qemu
-
-      - name: Extract QEMU into local path
-        run: tar -xf qemu.tar -C /usr/local/bin
-
-      - name: Check which QEMU is used
-        run: |
-          which qemu-system-arm
-          which qemu-system-riscv32
-
-      - name: Run-pass tests
-        run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.backend }} qemu
-  
-  # Platform hifive1: verify the example output with run-pass tests
-  testexampleshifive1:
-    name: QEMU run (hifive1)
-    needs: buildqemu
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        backend:
-          - riscv32-imc-clint
-          - riscv32-imc-mecall
-        toolchain:
-          - stable
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup set profile minimal
-          rustup override set ${{ matrix.toolchain }}
 
       - name: Configure Rust target
-        run: |
-          rustup target add riscv32imc-unknown-none-elf
+        run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Add Rust component llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
-      # Use precompiled binutils
-      - name: Install cargo-binutils
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-binutils
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-      
-      - name: Install QEMU to get dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y qemu-system-riscv32
-
-      - name: Download built QEMU
-        uses: actions/download-artifact@v4
-        with:
-          name: qemu
-      
-      - name: Extract QEMU into local path
-        run: tar -xf qemu.tar -C /usr/local/bin
-
-      - name: Check which QEMU is used
-        run: |
-          which qemu-system-arm
-          which qemu-system-riscv32
-      
-      - name: Run-pass tests
-        run: cargo xtask --deny-warnings --platform hifive1 --backend ${{ matrix.backend }} qemu
-
-  # Platform esp32c3: verify the example output with run-pass tests
-  testexamplesesp32c3:
-    name: QEMU run (esp32c3)
-    needs: buildqemu
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup set profile minimal
-          rustup override set ${{ matrix.toolchain }}
-
-      - name: Configure Rust target
-        run: |
-          rustup target add riscv32imac-unknown-none-elf
-          rustup target add riscv32imc-unknown-none-elf
-
-      - name: Add Rust component llvm-tools-preview
-        run: rustup component add llvm-tools-preview
-
-      - name: Install libudev espflash dependency
+      - name: Install lubudev espflash dependency
+        if: ${{ matrix.input.platform == 'esp32-c3' }}
         run: |
           sudo apt update
           sudo apt install -y libudev-dev
@@ -386,12 +287,11 @@ jobs:
 
       # Use precompiled if possible
       - name: Install espflash
+        if: ${{ matrix.input.platform == 'esp32-c3' }}
         run: cargo install espflash --version 3.1.0 --force
-        # uses: taiki-e/install-action@v2
-        # with:
-        #   tool: espflash
 
       - name: Install esptool.py
+        if: ${{ matrix.input.platform == 'esp32-c3' }}
         run: pip install esptool
 
       - name: Cache Dependencies
@@ -400,22 +300,22 @@ jobs:
       - name: Install QEMU to get dependencies
         run: |
           sudo apt update
-          sudo apt install -y qemu-system-riscv32
+          sudo apt install -y qemu-system-${{ matrix.input.qemu-system }}
 
       - name: Download built QEMU
         uses: actions/download-artifact@v4
         with:
           name: qemu
-      
-      - name: Extract ESP32 QEMU into local path
-        run: sudo tar --strip-components=1 -xf qemu.tar -C /usr/local/ esp32/
+
+      - name: Extract QEMU into local path
+        run: tar -xf qemu.tar -C /usr/local/bin
 
       - name: Check which QEMU is used
         run: |
-          which qemu-system-riscv32
-      
+          which qemu-system-${{ matrix.input.qemu-system }}
+
       - name: Run-pass tests
-        run: cargo xtask -v --platform esp32-c3 qemu
+        run: cargo xtask --deny-warnings --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} qemu
 
   # Run test suite
   tests:
@@ -852,9 +752,7 @@ jobs:
       - clippylm3s6965
       # - clippyhifive1 # TODO
       - checkexamples
-      - testexampleslm3s6965
-      - testexampleshifive1
-      - testexamplesesp32c3
+      - testexamples
       - tests
       - docs
       - mdbook

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,41 +33,36 @@ jobs:
       - name: cargo xtask fmt
         run:  cargo xtask --verbose fmt -c
 
-  # Compilation check (lm3s6965)
-  checklm3s6965:
+  # Compilation check
+  # TODO: check hifive1, esp32-c3
+  check:
     name: check (lm3s6965)
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        backend:
-          - thumbv7
-          - thumbv6
-          - thumbv8-base
-          - thumbv8-main
-        toolchain:
-          - stable
+        input:
+          - backend: thumbv7
+            rustup-target: thumbv7m-none-eabi
+
+          - backend: thumbv6
+            rustup-target: thumbv6m-none-eabi
+
+          - backend: thumbv8-base
+            rustup-target: thumbv8m.base-none-eabi
+
+          - backend: thumbv8-main
+            rustup-target: thumbv8m.main-none-eabi
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust ${{ matrix.toolchain }}
-        run: |
-          rustup override set ${{ matrix.toolchain }}
-
       - name: Configure Rust target (v6, v7, v8.b v8.m)
-        run: |
-          rustup target add thumbv7m-none-eabi
-          rustup target add thumbv6m-none-eabi
-          rustup target add thumbv8m.base-none-eabi
-          rustup target add thumbv8m.main-none-eabi
+        run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
-      - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.backend }} check
-
-  # Compilation check (hifive1) TODO
-  # checkhifive1:
+      - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.input.backend }} check
 
   # Clippy
   # TODO: clippy hifive1, esp32-c3
@@ -743,8 +738,7 @@ jobs:
     if: github.event_name == 'push' && success()
     needs:
       - formatcheck
-      - checklm3s6965
-      # - checkhifive1 # TODO
+      - check
       - clippy
       - checkexamples
       - testexamples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure Rust target
+      - name: Configure Rust target ${{ matrix.input.rustup-target }}
         run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Cache Dependencies
@@ -115,7 +115,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure Rust target
+      - name: Configure Rust target ${{ matrix.input.rustup-target }}
         run:  rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Add Rust component clippy
@@ -165,7 +165,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure Rust target
+      - name: Configure Rust target ${{ matrix.input.rustup-target }}
         run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Cache Dependencies
@@ -278,7 +278,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure Rust target
+      - name: Configure Rust target ${{ matrix.input.rustup-target }}
         run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Add Rust component llvm-tools-preview

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,35 +34,47 @@ jobs:
         run:  cargo xtask --verbose fmt -c
 
   # Compilation check
-  # TODO: check hifive1, esp32-c3
+  # TODO: check esp32-c3
   check:
-    name: check (lm3s6965)
+    name: check
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         input:
           - backend: thumbv7
+            platform: lm3s6965
             rustup-target: thumbv7m-none-eabi
 
           - backend: thumbv6
+            platform: lm3s6965
             rustup-target: thumbv6m-none-eabi
 
           - backend: thumbv8-base
+            platform: lm3s6965
             rustup-target: thumbv8m.base-none-eabi
 
           - backend: thumbv8-main
+            platform: lm3s6965
             rustup-target: thumbv8m.main-none-eabi
+
+          - backend: riscv32-imc-clint
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
+
+          - backend: riscv32-imc-mecall
+            platform: hifive1
+            rustup-target: riscv32imc-unknown-none-elf
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure Rust target (v6, v7, v8.b v8.m)
+      - name: Configure Rust target
         run: rustup target add ${{ matrix.input.rustup-target }}
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
-      - run: cargo xtask --deny-warnings --platform lm3s6965 --backend ${{ matrix.input.backend }} check
+      - run: cargo xtask --deny-warnings --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} check
 
   # Clippy
   # TODO: clippy esp32-c3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,53 +74,6 @@ jobs:
             platform: esp32-c3
             rustup-target: riscv32imc-unknown-none-elf
 
-  # Clippy
-  # TODO: put in clippy-check-example once esp32-c3 clippy is fixed
-  clippy:
-    name: clippy
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        input:
-          - backend: thumbv7
-            platform: lm3s6965
-            rustup-target: thumbv7m-none-eabi
-
-          - backend: thumbv6
-            platform: lm3s6965
-            rustup-target: thumbv6m-none-eabi
-
-          - backend: thumbv8-base
-            platform: lm3s6965
-            rustup-target: thumbv8m.base-none-eabi
-
-          - backend: thumbv8-main
-            platform: lm3s6965
-            rustup-target: thumbv8m.main-none-eabi
-
-          - backend: riscv32-imc-clint
-            platform: hifive1
-            rustup-target: riscv32imc-unknown-none-elf
-
-          - backend: riscv32-imc-mecall
-            platform: hifive1
-            rustup-target: riscv32imc-unknown-none-elf
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure Rust target ${{ matrix.input.rustup-target }}
-        run:  rustup target add ${{ matrix.input.rustup-target }}
-
-      - name: Add Rust component clippy
-        run: rustup component add clippy
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - run: cargo xtask --deny-warnings --platform ${{ matrix.input.platform }} --backend ${{ matrix.input.backend }} clippy
-
   buildqemu:
     name: Get modern QEMU, build and store
     runs-on: ubuntu-22.04

--- a/.github/workflows/clippy-check-example.yml
+++ b/.github/workflows/clippy-check-example.yml
@@ -1,0 +1,56 @@
+name: check-clippy-examples
+on:
+  workflow_call:
+    inputs:
+      backend:
+        description: The backend to execute for
+        required: true
+        type: string
+
+      platform:
+        description: The platform to execute for
+        required: true
+        type: string
+
+      # TODO: get this from `cargo xtask`!
+      rustup-target:
+        description: The rustup target to install
+        required: true
+        type: string
+
+      example-args:
+        description: Extra args to pass when checking examples
+        required: false
+        type: string
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    name: Validate platform ${{ inputs.platform }}, backend ${{ inputs.backend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Rust target ${{ inputs.rustup-target }}
+        run: rustup target add ${{ inputs.rustup-target }}
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - run: cargo xtask --deny-warnings check -p ${{ inputs.platform }} -b ${{ inputs.backend }}
+
+  check-examples:
+    runs-on: ubuntu-22.04
+    name: Check examples
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Rust target ${{ inputs.rustup-target }}
+        run: rustup target add ${{ inputs.rustup-target }}
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check the examples
+        run: cargo xtask example-check --platform ${{ inputs.platform }} --backend ${{ inputs.backend }} ${{ inputs.example-args }}

--- a/.github/workflows/clippy-check-example.yml
+++ b/.github/workflows/clippy-check-example.yml
@@ -54,3 +54,21 @@ jobs:
 
       - name: Check the examples
         run: cargo xtask example-check --platform ${{ inputs.platform }} --backend ${{ inputs.backend }} ${{ inputs.example-args }}
+
+  clippy:
+    runs-on: ubuntu-22.04
+    name: Run clippy
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure Rust target ${{ inputs.rustup-target }}
+      run:  rustup target add ${{ inputs.rustup-target }}
+
+    - name: Add Rust component clippy
+      run: rustup component add clippy
+
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - run: cargo xtask --deny-warnings --platform ${{ inputs.platform }} --backend ${{ inputs.backend }} clippy

--- a/rtic-macros/src/codegen/bindings/esp32c3.rs
+++ b/rtic-macros/src/codegen/bindings/esp32c3.rs
@@ -2,6 +2,7 @@
 pub use esp32c3::*;
 
 #[cfg(feature = "riscv-esp32c3")]
+#[allow(clippy::module_inception)]
 mod esp32c3 {
     use crate::{
         analyze::Analysis as CodegenAnalysis,
@@ -92,7 +93,7 @@ mod esp32c3 {
         for (&priority, name) in interrupt_ids.chain(
             app.hardware_tasks
                 .values()
-                .filter_map(|task| Some((&task.args.priority, &task.args.binds))),
+                .map(|task| (&task.args.priority, &task.args.binds)),
         ) {
             let es = format!(
                 "Maximum priority used by interrupt vector '{name}' is more than supported by hardware"
@@ -207,7 +208,7 @@ mod esp32c3 {
         stmts
     }
 
-    pub fn async_prio_limit(app: &App, analysis: &CodegenAnalysis) -> Vec<TokenStream2> {
+    pub fn async_prio_limit(_app: &App, analysis: &CodegenAnalysis) -> Vec<TokenStream2> {
         let max = if let Some(max) = analysis.max_async_prio {
             quote!(#max)
         } else {
@@ -232,7 +233,7 @@ mod esp32c3 {
         for (_, name) in interrupt_ids.chain(
             app.hardware_tasks
                 .values()
-                .filter_map(|task| Some((&task.args.priority, &task.args.binds))),
+                .map(|task| (&task.args.priority, &task.args.binds)),
         ) {
             if *name == dispatcher_name {
                 let ret = &("interrupt".to_owned() + &curr_cpu_id.to_string());

--- a/rtic-monotonics/src/esp32c3.rs
+++ b/rtic-monotonics/src/esp32c3.rs
@@ -49,8 +49,8 @@ impl TimerBackend {
     /// Use the prelude macros instead.
     pub fn _start(timer: SYSTIMER) {
         const INTERRUPT_MAP_BASE: u32 = 0x600c2000;
-        let interrupt_number = 37 as isize;
-        let cpu_interrupt_number = 31 as isize;
+        let interrupt_number = 37isize;
+        let cpu_interrupt_number = 31isize;
         unsafe {
             let intr_map_base = INTERRUPT_MAP_BASE as *mut u32;
             intr_map_base
@@ -65,7 +65,7 @@ impl TimerBackend {
 
             intr_prio_base
                 .offset(cpu_interrupt_number)
-                .write_volatile(15 as u32);
+                .write_volatile(15);
         }
         timer.conf().write(|w| w.timer_unit0_work_en().set_bit());
         timer

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -22,6 +22,7 @@ Example:
 
 ### Changed
 
+- Placate clippy
 - Updated esp32c3 dependency to v0.27.0
 
 ### Added

--- a/rtic/src/export/riscv_common.rs
+++ b/rtic/src/export/riscv_common.rs
@@ -1,4 +1,4 @@
-/// GENERIC RE-EXPORTS: needed for all RTIC backends
+//! GENERIC RE-EXPORTS: needed for all RTIC backends
 
 /// Read the stack pointer.
 #[inline(always)]

--- a/rtic/src/export/riscv_esp32c3.rs
+++ b/rtic/src/export/riscv_esp32c3.rs
@@ -57,8 +57,7 @@ where
 pub unsafe fn lock<T, R>(ptr: *mut T, ceiling: u8, f: impl FnOnce(&mut T) -> R) -> R {
     if ceiling == (15) {
         //turn off interrupts completely, were at max prio
-        let r = critical_section::with(|_| f(&mut *ptr));
-        r
+        critical_section::with(|_| f(&mut *ptr))
     } else {
         let current = unsafe {
             (*INTERRUPT_CORE0::ptr())

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -138,7 +138,7 @@ impl TestMetadata {
     }
 }
 
-#[derive(clap::ValueEnum, Copy, Clone, Default, Debug)]
+#[derive(clap::ValueEnum, Copy, Clone, Default, Debug, PartialEq)]
 pub enum Backends {
     Thumbv6,
     #[default]
@@ -193,7 +193,9 @@ impl Backends {
 
     #[allow(clippy::wrong_self_convention)]
     pub fn to_rtic_monotonics_features(&self, partial: bool) -> Option<&[&str]> {
-        if !self.is_arm() {
+        if self == &Self::RiscvEsp32C3 {
+            Some(&["esp32c3-systimer"])
+        } else if !self.is_arm() {
             None
         } else if partial {
             Some(&[


### PR DESCRIPTION
Instead of having a bunch of duplicate tasks, we can simply use/abuse the github matrices a little.

There's a bunch of repetition for platform/backend/toolchain combinations, but at least it's obvious what is and isn't being tested. We should be able to replace them with a YAML anchor [once that's supported][0]

Also add coverage for RISCV platforms/backends in clippy and check.

[0]: https://github.com/actions/runner/issues/1182