### PR TITLE
CI: Update QEMU: Ubuntu and ESP32-C3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ env:
   QEMU_VERSION: 8.2.0
   QEMU_URL: https://download.qemu.org/qemu-8.2.0.tar.xz
   QEMU_ESP: qemu_esp
-  QEMU_ESP_URL: https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz
+  QEMU_ESP_URL: https://github.com/espressif/qemu/releases/download/esp-develop-9.2.2-20250228/qemu-riscv32-softmmu-esp_develop_9.2.2_20250228-x86_64-linux-gnu.tar.xz
 
 jobs:
   # Run cargo xtask format-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Cache QEMU build
+      - name: Cache QEMU
         id: cache-qemu
         uses: actions/cache@v4
         with:
@@ -90,11 +90,10 @@ jobs:
             ${{ runner.OS }}-qemu-${{ env.QEMU_VERSION }}
             ${{ runner.OS }}-qemu-
 
-      - name: Install QEMU to get dependencies
+      - name: Install QEMU
         run: |
           sudo apt update
           sudo apt install -y qemu-system-arm qemu-system-riscv32
-          sudo apt install -y git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
 
       - name: Download ESP32 QEMU
         run: wget "${{ env.QEMU_ESP_URL }}" --output-document=${{ env.QEMU_ESP}}.tar.xz
@@ -104,12 +103,12 @@ jobs:
           mkdir -p qemu-${{ env.QEMU_VERSION }}/build/esp32
           tar --strip-components=1 -xvJf ${{ env.QEMU_ESP }}.tar.xz -C qemu-${{ env.QEMU_VERSION }}/build/esp32 qemu
 
-      - name: Archive QEMU build
+      - name: Archive QEMU
         run: |
           cd qemu-${{ env.QEMU_VERSION }}/build
           tar -cf $GITHUB_WORKSPACE/qemu.tar *
 
-      - name: Store QEMU build
+      - name: Store QEMU
         uses: actions/upload-artifact@v4
         with:
           name: qemu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,8 +73,8 @@ jobs:
             platform: esp32-c3
             rustup-target: riscv32imc-unknown-none-elf
 
-  buildqemu:
-    name: Get modern QEMU, build and store
+  installqemu:
+    name: Get modern QEMU and cache it
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -117,7 +117,7 @@ jobs:
   # Verify the example output with run-pass tests
   testexamples:
     name: QEMU run
-    needs: buildqemu
+    needs: installqemu
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ env:
   OLDSTABLE_VERSION: 1
   OLDOLDSTABLE_VERSION: 0.5
   OLDOLDOLDSTABLE_VERSION: 0.4
-  QEMU_VERSION: 8.2.0
-  QEMU_URL: https://download.qemu.org/qemu-8.2.0.tar.xz
+  QEMU_VERSION: 9.2.2
   QEMU_ESP: qemu_esp
   QEMU_ESP_URL: https://github.com/espressif/qemu/releases/download/esp-develop-9.2.2-20250228/qemu-riscv32-softmmu-esp_develop_9.2.2_20250228-x86_64-linux-gnu.tar.xz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,26 +97,6 @@ jobs:
           sudo apt install -y qemu-system-arm qemu-system-riscv32
           sudo apt install -y git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
 
-      - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
-        name: Download QEMU
-        run: wget "${{ env.QEMU_URL }}"
-
-      - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
-        name: Extract QEMU
-        run: tar xvJf qemu-${{ env.QEMU_VERSION }}.tar.xz
-
-      - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
-        name: Configure QEMU
-        run: |
-          cd qemu-${{ env.QEMU_VERSION }}
-          ./configure --target-list=arm-softmmu,riscv32-softmmu
-
-      - if: ${{ steps.cache-qemu.outputs.cache-hit != 'true' }}
-        name: Build QEMU
-        run: |
-          cd qemu-${{ env.QEMU_VERSION }}
-          ninja -C build
-
       - name: Download ESP32 QEMU
         run: wget "${{ env.QEMU_ESP_URL }}" --output-document=${{ env.QEMU_ESP}}.tar.xz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   # Run cargo xtask format-check
   formatcheck:
     name: cargo fmt
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
 
   buildqemu:
     name: Get modern QEMU, build and store
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
   testexamples:
     name: QEMU run
     needs: buildqemu
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         input:
@@ -231,7 +231,7 @@ jobs:
   # Run test suite
   tests:
     name: tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -267,7 +267,7 @@ jobs:
 
   loom-tests:
     name: rtic-sync loom tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -278,7 +278,7 @@ jobs:
   # Build documentation, check links
   docs:
     name: build docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -329,7 +329,7 @@ jobs:
   mdbook:
     name: build mdbook
     needs: docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -384,7 +384,7 @@ jobs:
   mdbookold:
     name: build docs and mdbook for older releases
     needs: pushtostablebranch
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -459,7 +459,7 @@ jobs:
 
   parseversion:
     name: Parse the master branch RTIC version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       branch: ${{ steps.parseversion.outputs.branch }}
       versionmajor: ${{ steps.parseversion.outputs.versionmajor }}
@@ -490,7 +490,7 @@ jobs:
   # This needs to run before book is built, as bookbuilding fetches from the branch
   pushtostablebranch:
     name: Also push branch into release/vX when pushing to master
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - ci-success
       - parseversion
@@ -522,7 +522,7 @@ jobs:
   # If all tests pass, then deploy stage is run
   deploy:
     name: deploy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - pushtostablebranch
       - docs
@@ -642,7 +642,7 @@ jobs:
 
   ghapages:
     name: Publish rtic.rs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - deploy
     steps:
@@ -674,7 +674,7 @@ jobs:
       - loom-tests
       - docs
       - mdbook
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Mark the job as a success
         run: exit 0

--- a/.github/workflows/clippy-check-example.yml
+++ b/.github/workflows/clippy-check-example.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Validate platform ${{ inputs.platform }}, backend ${{ inputs.backend }}
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
       - run: cargo xtask --deny-warnings check -p ${{ inputs.platform }} -b ${{ inputs.backend }}
 
   check-examples:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Check examples
     steps:
       - name: Checkout
@@ -56,7 +56,7 @@ jobs:
         run: cargo xtask example-check --platform ${{ inputs.platform }} --backend ${{ inputs.backend }} ${{ inputs.example-args }}
 
   clippy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Run clippy
     steps:
     - name: Checkout

--- a/ci/expected/esp32c3/monotonic.run
+++ b/ci/expected/esp32c3/monotonic.run
@@ -1,5 +1,3 @@
-QEMU 8.2.0 monitor - type 'help' for more information
-(qemu) q[K
 init
 hello from bar
 hello from baz

--- a/ci/expected/esp32c3/sw_and_hw.run
+++ b/ci/expected/esp32c3/sw_and_hw.run
@@ -1,5 +1,3 @@
-QEMU 8.2.0 monitor - type 'help' for more information
-(qemu) q[K
 init
 Inside high prio task, press button now!
 Leaving high prio task.

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 /**/*/target
 !Cargo.lock
+/**/qemuoutput.log

--- a/examples/esp32c3/runner.sh
+++ b/examples/esp32c3/runner.sh
@@ -18,14 +18,13 @@ espflash save-image --chip esp32c3 --merge "$outputfilenamecargo" "$outputfilena
 esptool.py image_info --version 2 "$outputfilename" 1>&2
 
 # Run in QEMU
-$qemuexec -nographic -monitor tcp:127.0.0.1:55555,server,nowait -icount 3 -machine esp32c3 -drive file="$outputfilename",if=mtd,format=raw -serial file:"$logfile" &
+$qemuexec -nographic -monitor tcp:127.0.0.1:55555,server,nowait -icount 3 -machine esp32c3 -drive file="$outputfilename",if=mtd,format=raw -serial file:"$logfile" > qemuoutput.log 2>&1 &
 
 # Let it run
 sleep 3s
 
 # Kill QEMU nicely by sending 'q' (quit) over tcp
-echo q | nc -N 127.0.0.1 55555
-
+echo q | nc -N 127.0.0.1 55555  >> qemuoutput.log 2>&1
 # Output that will be compared must be printed to stdout
 
 # Make boot phase silent, for debugging change, run with e.g.  $ `env DEBUGGING=true` cargo xtask....


### PR DESCRIPTION
- **CI: Update CI runner to Ubuntu 24.04**
- **CI: Ubuntu 24.04 packages QEMU 8.2.2**
- **CI: Use latest ESP32-QEMU: 9.2.2**
- **CI: ESP32-C3: Tweak runner script not print version**
- **CI: ESP32: Update expected outputs**
- **CI: ESP32: Ignore qemuoutput.log files**
- **CI: clippy-check-example: Bump ubuntu-24.04**
