### PR TITLE
fix(doc): add safety notices to `Sender::send` and `Arbiter::access`

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -8,6 +8,8 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 ## [Unreleased]
 
 - Avoid a critical section when a `send`-link is popped and when returning `free_slot`.
+- Add safety notices to `Sender::send` and `Arbiter::access` (you cant `forget` them).
+
 ### Changed
 
 - Add `loom` support.

--- a/rtic-sync/src/arbiter.rs
+++ b/rtic-sync/src/arbiter.rs
@@ -74,7 +74,7 @@ impl<T> Arbiter<T> {
     /// # Safety
     ///
     /// This method assumes that the future returned by this method is not forgotten. Apis like [`core::mem::forget`],
-    /// [`core::mem::ManuallyDrop::new`] and [`std::boxed::Box::leak`] may cause undefined behavior.
+    /// [`core::mem::ManuallyDrop::new`] and `Box::leak` may cause undefined behavior.
     pub async fn access(&self) -> ExclusiveAccess<'_, T> {
         let mut link_ptr: Option<Link<Waker>> = None;
 

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -371,7 +371,7 @@ impl<T, const N: usize> Sender<'_, T, N> {
     /// # Safety
     ///
     /// This method assumes that the future returned by this method is not forgotten. Apis like [`core::mem::forget`],
-    /// [`core::mem::ManuallyDrop::new`] and [`std::boxed::Box::leak`] may cause undefined behavior.
+    /// [`core::mem::ManuallyDrop::new`] and `Box::leak` may cause undefined behavior.
     pub async fn send(&mut self, val: T) -> Result<(), NoReceiver<T>> {
         let mut free_slot_ptr: Option<u8> = None;
         let mut link_ptr: Option<Link<WaitQueueData>> = None;


### PR DESCRIPTION
Hello, those methods are technically unsound, because you can create the future, `poll` it, it will register the link to the queue, than you can `core::mem::forget` that future and return from the function, that will deallocate stack frame. But other links will still have those pointers, causing use after free and memory corruption.

