### PR TITLE
feat: do not cause memory corruption if `remove_from_list` (safe function) is called multiple times

### DIFF
--- a/rtic-common/CHANGELOG.md
+++ b/rtic-common/CHANGELOG.md
@@ -7,6 +7,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+- Fix minor unsoundnes in `Link::remove_from_list`.
+
 ### Added
 
 ### Changed

--- a/rtic-common/src/wait_queue.rs
+++ b/rtic-common/src/wait_queue.rs
@@ -141,11 +141,12 @@ impl<T: Clone> Link<T> {
     /// Remove this link from a linked list.
     pub fn remove_from_list(&self, list: &DoublyLinkedList<T>) {
         cs::with(|_| {
+            // Make sure all previous writes are visible
+            core::sync::atomic::fence(Ordering::SeqCst);
+
             if self.is_popped() {
                 return;
             }
-            // Make sure all previous writes are visible
-            core::sync::atomic::fence(Ordering::SeqCst);
 
             let prev = self.prev.load(Self::R);
             let next = self.next.load(Self::R);

--- a/rtic-common/src/wait_queue.rs
+++ b/rtic-common/src/wait_queue.rs
@@ -140,6 +140,10 @@ impl<T: Clone> Link<T> {
 
     /// Remove this link from a linked list.
     pub fn remove_from_list(&self, list: &DoublyLinkedList<T>) {
+        if self.is_popped() {
+            return;
+        }
+
         cs::with(|_| {
             // Make sure all previous writes are visible
             core::sync::atomic::fence(Ordering::SeqCst);

--- a/rtic-common/src/wait_queue.rs
+++ b/rtic-common/src/wait_queue.rs
@@ -140,11 +140,10 @@ impl<T: Clone> Link<T> {
 
     /// Remove this link from a linked list.
     pub fn remove_from_list(&self, list: &DoublyLinkedList<T>) {
-        if self.is_popped() {
-            return;
-        }
-
         cs::with(|_| {
+            if self.is_popped() {
+                return;
+            }
             // Make sure all previous writes are visible
             core::sync::atomic::fence(Ordering::SeqCst);
 


### PR DESCRIPTION
`Link::remove_from_list` is safe, but if you will call it several times, it will again change the list. If it was changed in between those calls, state would be corrupted. This can be fixed either by setting `self.next` and `self.prev` to `null_mut()` after removing the node, or by using already present `is_popped` boolean.