### PR TITLE
feat: `wait_until` method for the wait_queue 

### DIFF
--- a/ci/expected/lm3s6965/wait-queue.run
+++ b/ci/expected/lm3s6965/wait-queue.run
@@ -1,0 +1,4 @@
+Inc
+Inc
+Inc
+Got 3

--- a/examples/lm3s6965/Cargo.toml
+++ b/examples/lm3s6965/Cargo.toml
@@ -16,6 +16,7 @@ bare-metal = "1.0.0"
 cortex-m-semihosting = "0.5.0"
 rtic-time = { path = "../../rtic-time" }
 rtic-sync = { path = "../../rtic-sync" }
+rtic-common = { path = "../../rtic-common" }
 rtic-monotonics = { path = "../../rtic-monotonics", features = ["cortex-m-systick"] }
 rtic = { path = "../../rtic" }
 cfg-if = "1.0"

--- a/examples/lm3s6965/examples/wait-queue.rs
+++ b/examples/lm3s6965/examples/wait-queue.rs
@@ -1,0 +1,64 @@
+//! examples/wait-queue.rs
+
+#![no_main]
+#![no_std]
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+
+use panic_semihosting as _;
+
+#[rtic::app(device = lm3s6965, dispatchers = [GPIOA])]
+mod app {
+    use cortex_m_semihosting::{debug, hprintln};
+    use rtic_common::wait_queue::WaitQueue;
+
+    use rtic_monotonics::systick::prelude::*;
+    systick_monotonic!(Mono, 100);
+
+    #[shared]
+    struct Shared {
+        count: u32,
+    }
+
+    #[local]
+    struct Local {}
+
+    #[init(local = [wait_queue: WaitQueue = WaitQueue::new()])]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        Mono::start(cx.core.SYST, 12_000_000);
+
+        incrementer::spawn(cx.local.wait_queue).ok().unwrap();
+        waiter::spawn(cx.local.wait_queue).ok().unwrap();
+
+        let count = 0;
+
+        (Shared { count }, Local {})
+    }
+
+    #[task(shared = [count])]
+    async fn incrementer(mut c: incrementer::Context, wait_queue: &'static WaitQueue) {
+        loop {
+            hprintln!("Inc");
+
+            c.shared.count.lock(|c| *c += 1);
+
+            while let Some(waker) = wait_queue.pop() {
+                waker.wake();
+            }
+
+            Mono::delay(10.millis()).await;
+        }
+    }
+
+    #[task(shared = [count])]
+    async fn waiter(mut c: waiter::Context, wait_queue: &'static WaitQueue) {
+        let value = wait_queue
+            .wait_until(|| c.shared.count.lock(|c| (*c >= 3).then_some(*c)))
+            .await;
+
+        hprintln!("Got {}", value);
+
+        debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator
+    }
+}

--- a/rtic-common/CHANGELOG.md
+++ b/rtic-common/CHANGELOG.md
@@ -11,6 +11,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Added
 
+- New safe `WaitQueue::wait_until` method.
+
 ### Changed
 
 ### Fixed

--- a/rtic-common/src/dropper.rs
+++ b/rtic-common/src/dropper.rs
@@ -1,5 +1,9 @@
 //! A drop implementation runner.
 
+use core::ops::{Deref, DerefMut};
+
+pub(crate) struct OnDropWith<T, F: FnMut(&mut T)>(T, F);
+
 /// Runs a closure on drop.
 pub struct OnDrop<F: FnOnce()> {
     f: core::mem::MaybeUninit<F>,
@@ -22,5 +26,35 @@ impl<F: FnOnce()> OnDrop<F> {
 impl<F: FnOnce()> Drop for OnDrop<F> {
     fn drop(&mut self) {
         unsafe { self.f.as_ptr().read()() }
+    }
+}
+
+impl<T, F: FnMut(&mut T)> OnDropWith<T, F> {
+    pub(crate) fn new(value: T, f: F) -> Self {
+        Self(value, f)
+    }
+
+    pub(crate) fn execute(&mut self) {
+        (self.1)(&mut self.0);
+    }
+}
+
+impl<T, F: FnMut(&mut T)> Deref for OnDropWith<T, F> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, F: FnMut(&mut T)> DerefMut for OnDropWith<T, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T, F: FnMut(&mut T)> Drop for OnDropWith<T, F> {
+    fn drop(&mut self) {
+        self.execute();
     }
 }

--- a/rtic-common/src/wait_queue.rs
+++ b/rtic-common/src/wait_queue.rs
@@ -289,6 +289,24 @@ impl<T: core::fmt::Debug + Clone> Link<T> {
     }
 }
 
+/// Test that the future returned by `wait_until` is not `Unpin`.
+/// ```compile_fail
+/// fn test_unpin(list: &rtic_common::wait_queue::DoublyLinkedList<core::task::Waker>, cx: &mut core::task::Context) {
+///     let mut wait_until_future = list.wait_until(|| None::<()>);
+///     let pinned = core::pin::Pin::new(&mut wait_until_future);
+///     core::future::Future::poll(pinned, cx);
+///  }
+/// ```
+/// This test will ensure that previous test failed because of `pin`.
+/// ```
+/// fn test_unpin(list: &rtic_common::wait_queue::DoublyLinkedList<core::task::Waker>, cx: &mut core::task::Context) {
+///     let mut wait_until_future = list.wait_until(|| None::<()>);
+///     let pinned = core::pin::pin!(wait_until_future);
+///     core::future::Future::poll(pinned, cx);
+///  }
+/// ```
+mod compile_fail_test {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
For some reason github cannot understand that this is the same branch, so I forced to make the second PR after #1052

Diatomic Waker has a [method like this](https://docs.rs/diatomic-waker/latest/diatomic_waker/struct.WakeSinkRef.html#method.wait_until) and it is very handy. I've been implementing async wrapper over [heapless::mpmc::MpMcQueue](https://docs.rs/heapless/latest/heapless/mpmc/struct.MpMcQueue.html) and wait_queue is great, but a method like this is really benefitial. You can *safely* create async versions of `enqueue` and `dequeue`, and don't need `unsafe` to interact with the `wait_queue`.

Note that this PR has only 1 additional `unsafe` block.

To give a perspective, this method is used like that :

```rust
impl<T, const N: usize> MpMcChannel<T, N> {
    pub const fn new() -> Self {
        Self {
            tx_wait_queue: WaitQueue::new(),
            rx_wait_queue: WaitQueue::new(),
            queue: MpMcQueue::new(),
        }
    }

    pub fn try_send(&self, value: T) -> Result<(), T> {
        // wakes should actually be after successful enqueue
        while let Some(waker) = self.rx_wait_queue.pop() {
            waker.wake();
        }

        self.queue.enqueue(value)
    }

    pub fn try_recv(&self) -> Option<T> {
        // wakes should actually be after successful dequeue
        while let Some(waker) = self.rx_wait_queue.pop() {
            waker.wake();
        }

        self.queue.dequeue()
    }

    pub async fn send(&self, value: T) {
        let mut value = Some(value);
        self.tx_wait_queue
            .wait_until(|| {
                self.try_send(value.take().expect("Future is polled after completion"))
                    .map_err(|old_val| value = Some(old_val))
                    .ok()
            })
            .await
    }

    pub async fn recv(&self) -> T {
        self.rx_wait_queue.wait_until(|| self.try_recv()).await
    }
}
```