### PR TITLE
docs: rtic-time, monotonic, monotonics

### DIFF
--- a/rtic-monotonics/README.md
+++ b/rtic-monotonics/README.md
@@ -3,7 +3,7 @@
 
 # `rtic-monotonics`
 
-> Core abstractions of the Real-Time Interrupt-driven Concurrency (RTIC) Monotonics timers
+> Reference implementations of the Real-Time Interrupt-driven Concurrency (RTIC) Monotonics timers
 
 `rtic-monotonics` is for RTIC v2.
 

--- a/rtic-monotonics/README.md
+++ b/rtic-monotonics/README.md
@@ -5,6 +5,8 @@
 
 > Reference implementations of the Real-Time Interrupt-driven Concurrency (RTIC) Monotonics timers
 
+Uses [`rtic-time`](https://github.com/rtic-rs/rtic/tree/master/rtic-time) defined [`Monotonic`](https://docs.rs/rtic-time/latest/rtic_time/trait.Monotonic.html) trait.
+
 `rtic-monotonics` is for RTIC v2.
 
 For RTIC v1 see [`rtic-monotonic`](https://github.com/rtic-rs/rtic-monotonic)

--- a/rtic-time/README.md
+++ b/rtic-time/README.md
@@ -15,9 +15,12 @@ Additionally, this crate provides tools and utilities that help with implementin
 
 ## Implementations of the `Monotonic` trait
 
-For implementations of [`Monotonic`](https://docs.rs/rtic-time/latest/rtic_time/trait.Monotonic.html)
+Check the HAL crate of your device: it might already contain an implementation.
+
+For reference implementations of [`Monotonic`](https://docs.rs/rtic-time/latest/rtic_time/trait.Monotonic.html)
 on various hardware, see [`rtic-monotonics`](https://docs.rs/rtic-monotonics/).
 
+## RTIC v1 uses [`rtic-monotonic`](https://github.com/rtic-rs/rtic-monotonic) instead
 
 ## Chat
 


### PR DESCRIPTION
- **docs: Monotonics crates: Fix old copy-paste**
- **docs: Monotonics: Highlight rtic-time is used**


The newcomer to this space usually fails to relate the term "monotonic" with their needs of dealing with "time".

Thus the crate `rtic-time`:

> Basic definitions and utilities that can be used to keep track of time.

bridges the gap towards the `Monotonic` trait inside.

It may not have been intentional to name the reference implementations `rtic-monotonic*s*`,
but considering the crate contains a whole set of different implmentations targeting various producs it might be the better choice. And that it distinctively does not provide the `Monotonic` trait sets it apart from the old RTIC v1 `rtic-monotonic`.

Ideally, with time whatever was in here can be absorbed into each products relevant HAL crate(s).

Related PR: https://github.com/rtic-rs/rtic-monotonic/pull/12

Closes #1061
