### PR TITLE
Correct timer type in "Delay and Timeout using Monotonics"

### DIFF
--- a/book/en/src/by-example/delay.md
+++ b/book/en/src/by-example/delay.md
@@ -21,7 +21,7 @@ A _software_ task can `await` the delay to expire:
 #[task]
 async fn foo(_cx: foo::Context) {
     ...
-    Systick::delay(100.millis()).await;
+    Mono::delay(100.millis()).await;
     ...
 }
 

--- a/book/en/src/by-example/delay.md
+++ b/book/en/src/by-example/delay.md
@@ -1,4 +1,4 @@
-# Tasks with delay
+# Delay and Timeout using Monotonics
 
 A convenient way to express miniminal timing requirements is by delaying progression.
 
@@ -53,7 +53,7 @@ Rust [`Future`]s (underlying Rust `async`/`await`) are composable. This makes it
 
 [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
 
-A common use case is transactions with an associated timeout. In the examples shown below, we introduce a fake HAL device that performs some transaction. We have modelled the time it takes based on the input parameter (`n`) as `350ms + n * 100ms`.
+A common use case is transactions with an associated timeout. In the examples shown below, we introduce a fake HAL device that performs some imagined transaction when you call `hal_get(n).await`. We have modelled the time it takes based on the input parameter (`n`) as `350ms + n * 100ms`.
 
 Using the `select_biased` macro from the `futures` crate it may look like this:
 
@@ -65,9 +65,7 @@ Assuming the `hal_get` will take 450ms to finish, a short timeout of 200ms will 
 
 Extending the timeout to 1000ms would cause `hal_get` will to complete first.
 
-Using `select_biased` any number of futures can be combined, so its very powerful. However, as the timeout pattern is frequently used, more ergonomic support is baked into RTIC, provided by the [`rtic-monotonics`] and [`rtic-time`] crates.
-
-Rewriting the second example from above using `timeout_after` gives:
+Using `select_biased` any number of futures can be combined, so its very powerful. However, as the timeout pattern is frequently used, more ergonomic support is baked into RTIC, provided by the [`rtic-monotonics`] and [`rtic-time`] crates. Here's another example, using `Mono::delay_until` and `Mono::timeout_after`:
 
 ```rust,noplayground
 {{#include ../../../../examples/lm3s6965/examples/async-timeout.rs:timeout_at_basic}}
@@ -75,19 +73,15 @@ Rewriting the second example from above using `timeout_after` gives:
 
 In cases where you want exact control over time without drift we can use exact points in time using `Instant`, and spans of time using `Duration`. Operations on the `Instant` and `Duration` types come from the [`fugit`] crate.
 
-[fugit]: https://crates.io/crates/fugit
+[`fugit`]: https://crates.io/crates/fugit
 
-`let mut instant = Systick::now()` sets the starting time of execution.
+`let mut instant = Mono::now()` sets the starting time of execution.
 
-We want to call `hal_get` after 1000ms relative to this starting time. This can be accomplished by using `Systick::delay_until(instant).await`.
+We want to call `hal_get` every 1000ms relative to this starting time. We accomplish this by incrementing our `instant` by 1000 ms and then using `Mono::delay_until(instant).await`. Any additional delays incurred as we iterate around this loop are compensated for by delaying until 'previous + 1000' as opposed to 'now + 1000' (which would cause our loop timing to drift).
 
-Then, we define a point in time called `timeout`, and call `Systick::timeout_at(timeout, hal_get(n)).await`.
+To show an alternative to the `select!` async timeout example above, we define a future point in time as `timeout`, and call `Mono::timeout_at(timeout, hal_get(n)).await`.
 
-For the first iteration of the loop, with `n == 0`, the `hal_get` will take 350ms (and finishes before the timeout).
-
-For the second iteration, with `n == 1`, the `hal_get` will take 450ms (and again succeeds to finish before the timeout).
-
-For the third iteration, with `n == 2`, `hal_get` will take 550ms to finish, in which case we will run into a timeout.
+For the first iteration of the loop, with `n == 0`, the `hal_get` will take 350ms (as described above), and finishes before the timeout. For the second iteration, the delay is 450ms, which still finishes before the timeout. For the third iteration, with `n == 2`, `hal_get` will take 550ms to finish, in which case we will run into a timeout.
 
 <details>
 <summary>A complete example</summary>

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -1,4 +1,5 @@
 //! [`Monotonic`](rtic_time::Monotonic) based on Cortex-M SysTick.
+//!
 //! Note: this implementation is inefficient as it
 //! ticks and generates interrupts at a constant rate.
 //!
@@ -9,11 +10,9 @@
 //! systick_monotonic!(Mono, 1_000);
 //!
 //! fn init() {
-//!     # // This is normally provided by the selected PAC
-//!     # let systick = unsafe { core::mem::transmute(()) };
-//!     #
-//!     // Start the monotonic
-//!     Mono::start(systick, 12_000_000);
+//!     let core_peripherals = cortex_m::Peripherals::take().unwrap();
+//!     // Start the monotonic using the cortex-m crate's Systick driver
+//!     Mono::start(core_peripherals.SYST, 12_000_000);
 //! }
 //!
 //! async fn usage() {
@@ -133,6 +132,15 @@ impl TimerQueueBackend for SystickBackend {
 }
 
 /// Create a Systick based monotonic and register the Systick interrupt for it.
+///
+/// This macro expands to produce a new type called `$name`, which has a `fn
+/// start()` function for you to call. The type has an implementation of the
+/// `rtic_monotonics::TimerQueueBasedMonotonic` trait, the
+/// `embedded_hal::delay::DelayNs` trait and the
+/// `embedded_hal_async::delay::DelayNs` trait.
+///
+/// This macro also produces an interrupt handler for the SysTick interrupt, by
+/// creating an `extern "C" fn SysTick() { ... }`.
 ///
 /// See [`crate::systick`] for more details.
 ///


### PR DESCRIPTION
The example in `lm3s6965/examples/async-timeout.rs` uses `Mono` as the monotonic timer type, so it's confusing that the second example switches to using `Systick`.