### PR TITLE
ci: QEMU ESP32: Update espflash to 3.3.0, speed up CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,12 +161,6 @@ jobs:
       - name: Add Rust component llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
-      - name: Install lubudev espflash dependency
-        if: contains(matrix.input.platform, 'esp32')
-        run: |
-          sudo apt update
-          sudo apt install -y libudev-dev
-
       # Use precompiled binutils
       - name: Install cargo-binutils
         uses: taiki-e/install-action@v2
@@ -176,7 +170,7 @@ jobs:
       # Use precompiled if possible
       - name: Install espflash
         if: contains(matrix.input.platform, 'esp32')
-        run: cargo install espflash --version 3.1.0 --force
+        run: cargo install espflash --version 3.3.0 --force --no-default-features --features cli
 
       - name: Install esptool.py
         if: contains(matrix.input.platform, 'esp32')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,12 +178,13 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Install QEMU to get dependencies
+      - name: Install QEMU
         run: |
           sudo apt update
           sudo apt install -y qemu-system-${{ matrix.input.qemu-system }}
 
       - name: Download built QEMU
+        if: contains(matrix.input.platform, 'esp32')
         uses: actions/download-artifact@v4
         with:
           name: qemu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,9 +95,11 @@ jobs:
             ${{ runner.OS }}-qemu-
 
       - name: Download ESP32 QEMU
+        if: steps.installqemu.outputs.cache-hit != 'true'
         run: wget "${{ env.QEMU_ESP_URL }}" --output-document=${{ env.QEMU_ESP}}.tar.xz
 
       - name: Extract ESP32 QEMU
+        if: steps.installqemu.outputs.cache-hit != 'true'
         run: |
           mkdir -p qemu-${{ env.QEMU_VERSION }}/build/esp32
           tar --strip-components=1 -xvJf ${{ env.QEMU_ESP }}.tar.xz -C qemu-${{ env.QEMU_VERSION }}/build/esp32 qemu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
             rustup-target: riscv32imac-unknown-none-elf
 
   installqemu:
-    name: Get modern QEMU and cache it
+    name: Get ESP32 QEMU and cache it
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -93,11 +93,6 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-qemu-${{ env.QEMU_VERSION }}
             ${{ runner.OS }}-qemu-
-
-      - name: Install QEMU
-        run: |
-          sudo apt update
-          sudo apt install -y qemu-system-arm qemu-system-riscv32
 
       - name: Download ESP32 QEMU
         run: wget "${{ env.QEMU_ESP_URL }}" --output-document=${{ env.QEMU_ESP}}.tar.xz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,9 @@ jobs:
       # Use precompiled if possible
       - name: Install espflash
         if: contains(matrix.input.platform, 'esp32')
-        run: cargo install espflash --version 3.3.0 --force --no-default-features --features cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: espflash
 
       - name: Install esptool.py
         if: contains(matrix.input.platform, 'esp32')


### PR DESCRIPTION
Use `cargo binstall` for espflash

Do not install QEMU needlessly
Rework cache fetches for QEMU

Cuts CI runtime usage minutes in half: from ~2 hours to ~1 hour

2h 4m 22s: random PR CI: https://github.com/rtic-rs/rtic/actions/runs/15662419953/usage
58m 19s: this PR