### PR TITLE
Require exclusive access to the RESET peripheral for RP2040/RP2350

### DIFF
--- a/rtic-monotonics/src/rp2040.rs
+++ b/rtic-monotonics/src/rp2040.rs
@@ -50,7 +50,7 @@ impl TimerBackend {
     /// **Do not use this function directly.**
     ///
     /// Use the prelude macros instead.
-    pub fn _start(timer: TIMER, resets: &RESETS) {
+    pub fn _start(timer: TIMER, resets: &mut RESETS) {
         resets.reset().modify(|_, w| w.timer().clear_bit());
         while resets.reset_done().read().timer().bit_is_clear() {}
         timer.inte().modify(|_, w| w.alarm_0().bit(true));

--- a/rtic-monotonics/src/rp235x.rs
+++ b/rtic-monotonics/src/rp235x.rs
@@ -52,7 +52,7 @@ impl TimerBackend {
     /// **Do not use this function directly.**
     ///
     /// Use the prelude macros instead.
-    pub fn _start(timer: TIMER0, resets: &RESETS) {
+    pub fn _start(timer: TIMER0, resets: &mut RESETS) {
         resets.reset().modify(|_, w| w.timer0().clear_bit());
         while resets.reset_done().read().timer0().bit_is_clear() {}
         timer.inte().modify(|_, w| w.alarm_0().bit(true));


### PR DESCRIPTION
If you don't have exclusive access to the RESET peripheral, someone else could race you on the read/modify/write cycle on the update of the RESETS.reset register.

This is a breaking change.