### PR TITLE
docs/readme/xtaskandlinkfixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ Report bugs by creating an issue in this repository.
 
 Please make pull requests against the master branch.
 
-Always use rebase instead of merge when bringing in changes from master to your feature branch.
+Always use **rebase** instead of merge when bringing in changes from master to your feature branch.
+
+For non-trivial PRs add an entry in relevant `CHANGELOG` at the **top** of appropriate category: *Added*, *Changed*, *Fixed*.
 
 ## Writing documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,7 @@
 
 ## New features
 
-New features should go through the [RFC process][rfcs] before creating a Pull Request to this repository.
-
-[rfcs]: https://github.com/rtic-rs/rfcs
+Create an issue describing the feature. For more interactive discussions join the regular weekly meeting - see README.
 
 ## Bugs
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This crate is based on the [Real-Time For the Masses language][rtfm-lang]
 created by the Embedded Systems group at [Luleå University of Technology][ltu],
 led by [Prof. Per Lindgren][perl].
 
-[rtfm-lang]: http://www.rtfm-lang.org/
+[rtfm-lang]: https://web.archive.org/web/20220401050805/http://www.rtfm-lang.org/
 [ltu]: https://www.ltu.se/?l=en
 [perl]: https://www.ltu.se/staff/p/pln-1.11258?l=en
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,26 @@ New features and big changes should go through the RFC process in the
 
 ## Running tests locally
 
-To check all `Run-pass tests` locally on your `thumbv6m-none-eabi` or `thumbv7m-none-eabi` target device, run
+To check all `tests` locally, make sure you got QEMU (and ESP32 QEMU if so desired)
+then:
 
 ```console
-$ cargo xtask --target <your target>
-#                       ˆˆˆˆˆˆˆˆˆˆˆˆ
-#                   e.g. thumbv7m-none-eabi
+$ cargo xtask ci
 ```
+
+To only format code before PR (included in `ci` above):
+
+```console
+$ cargo xtask fmt
+```
+
+Clippy lints:
+
+```console
+$ cargo xtask clippy
+```
+and so on. See `cargo xtask --help` for all options.
+
 
 ## Acknowledgments
 

--- a/book/en/theme/favicon.svg
+++ b/book/en/theme/favicon.svg
@@ -1,0 +1,1 @@
+../src/RTIC.svg


### PR DESCRIPTION
- **book: Add favicon**
- **README: Point to rtfm-lang.org archive.org**
- **contributing: RFC repo is not used as intended**
- **contributing: Add note about changelog entries**
- **docs: README: Rework how to use cargo xtask**
