### PR TITLE
[rtic-monotonics] Panic if STM32 clock prescaler value overflows

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -7,6 +7,9 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
+### Changed
+- Panic if STM32 prescaler value would overflow
+
 ## v2.1.0 - 2025-06-22
 
 ### Changed

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -238,8 +238,10 @@ macro_rules! make_timer {
                 $timer.cr1().modify(|r| r.set_cen(false));
 
                 assert!((tim_clock_hz % timer_hz) == 0, "Unable to find suitable timer prescaler value!");
-                let psc = tim_clock_hz / timer_hz - 1;
-                $timer.psc().write(|r| r.set_psc(psc as u16));
+                let Ok(psc) = u16::try_from(tim_clock_hz / timer_hz - 1) else {
+                    panic!("Clock prescaler overflowed!");
+                };
+                $timer.psc().write(|r| r.set_psc(psc));
 
                 // Enable full-period interrupt.
                 $timer.dier().modify(|r| r.set_uie(true));


### PR DESCRIPTION
I recently had a confusing issue on my STM32 board where I used a TIMx driver for `Monotonic` and the timer was progressing ~5.5x faster than it should have been. The system clock was 80MHz and I used 1000 ticks per second for the timer. Turns out there was an overflow in the prescaler configuration. This PR adds an assertion in that case, to make debugging this problem easier for other users in the future.