### PR TITLE
Extend xtask with diffing binary size capabilities

### DIFF
--- a/ci/expected/lm3s6965/async-channel-done.size
+++ b/ci/expected/lm3s6965/async-channel-done.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+  10244	      0	     84	  10328	   2858	async-channel-done

--- a/ci/expected/lm3s6965/async-channel-no-receiver.size
+++ b/ci/expected/lm3s6965/async-channel-no-receiver.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   8620	      0	     72	   8692	   21f4	async-channel-no-receiver

--- a/ci/expected/lm3s6965/async-channel-no-sender.size
+++ b/ci/expected/lm3s6965/async-channel-no-sender.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   8284	      0	     72	   8356	   20a4	async-channel-no-sender

--- a/ci/expected/lm3s6965/async-channel-try.size
+++ b/ci/expected/lm3s6965/async-channel-try.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+  10276	      0	     76	  10352	   2870	async-channel-try

--- a/ci/expected/lm3s6965/async-channel.size
+++ b/ci/expected/lm3s6965/async-channel.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+  10216	      0	    108	  10324	   2854	async-channel

--- a/ci/expected/lm3s6965/async-delay.size
+++ b/ci/expected/lm3s6965/async-delay.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   7724	      0	     36	   7760	   1e50	async-delay

--- a/ci/expected/lm3s6965/async-task-multiple-prios.size
+++ b/ci/expected/lm3s6965/async-task-multiple-prios.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6652	      0	     32	   6684	   1a1c	async-task-multiple-prios

--- a/ci/expected/lm3s6965/async-task.size
+++ b/ci/expected/lm3s6965/async-task.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   8180	      0	     24	   8204	   200c	async-task

--- a/ci/expected/lm3s6965/async-timeout.size
+++ b/ci/expected/lm3s6965/async-timeout.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+  16052	      0	     28	  16080	   3ed0	async-timeout

--- a/ci/expected/lm3s6965/big-struct-opt.size
+++ b/ci/expected/lm3s6965/big-struct-opt.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   7668	      0	   2064	   9732	   2604	big-struct-opt

--- a/ci/expected/lm3s6965/binds.size
+++ b/ci/expected/lm3s6965/binds.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5284	      0	     16	   5300	   14b4	binds

--- a/ci/expected/lm3s6965/common.size
+++ b/ci/expected/lm3s6965/common.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   7352	      0	     44	   7396	   1ce4	common

--- a/ci/expected/lm3s6965/complex.size
+++ b/ci/expected/lm3s6965/complex.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6708	      0	     36	   6744	   1a58	complex

--- a/ci/expected/lm3s6965/declared_locals.size
+++ b/ci/expected/lm3s6965/declared_locals.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4540	      0	      4	   4544	   11c0	declared_locals

--- a/ci/expected/lm3s6965/destructure.size
+++ b/ci/expected/lm3s6965/destructure.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6004	      0	     32	   6036	   1794	destructure

--- a/ci/expected/lm3s6965/executor-size.size
+++ b/ci/expected/lm3s6965/executor-size.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5612	      0	     24	   5636	   1604	executor-size

--- a/ci/expected/lm3s6965/extern_binds.size
+++ b/ci/expected/lm3s6965/extern_binds.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4784	      0	     12	   4796	   12bc	extern_binds

--- a/ci/expected/lm3s6965/extern_spawn.size
+++ b/ci/expected/lm3s6965/extern_spawn.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5272	      0	     16	   5288	   14a8	extern_spawn

--- a/ci/expected/lm3s6965/generics.size
+++ b/ci/expected/lm3s6965/generics.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5392	      0	     24	   5416	   1528	generics

--- a/ci/expected/lm3s6965/hardware.size
+++ b/ci/expected/lm3s6965/hardware.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5288	      0	     16	   5304	   14b8	hardware

--- a/ci/expected/lm3s6965/idle-wfi.size
+++ b/ci/expected/lm3s6965/idle-wfi.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4704	      0	     12	   4716	   126c	idle-wfi

--- a/ci/expected/lm3s6965/idle.size
+++ b/ci/expected/lm3s6965/idle.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4684	      0	     12	   4696	   1258	idle

--- a/ci/expected/lm3s6965/init.size
+++ b/ci/expected/lm3s6965/init.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4652	      0	     12	   4664	   1238	init

--- a/ci/expected/lm3s6965/locals.size
+++ b/ci/expected/lm3s6965/locals.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   7352	      0	     44	   7396	   1ce4	locals

--- a/ci/expected/lm3s6965/lock-free.size
+++ b/ci/expected/lm3s6965/lock-free.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6392	      0	     20	   6412	   190c	lock-free

--- a/ci/expected/lm3s6965/lock.size
+++ b/ci/expected/lm3s6965/lock.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6448	      0	     28	   6476	   194c	lock

--- a/ci/expected/lm3s6965/multilock.size
+++ b/ci/expected/lm3s6965/multilock.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5696	      0	     28	   5724	   165c	multilock

--- a/ci/expected/lm3s6965/not-sync.size
+++ b/ci/expected/lm3s6965/not-sync.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6012	      0	     24	   6036	   1794	not-sync

--- a/ci/expected/lm3s6965/only-shared-access.size
+++ b/ci/expected/lm3s6965/only-shared-access.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6180	      0	     24	   6204	   183c	only-shared-access

--- a/ci/expected/lm3s6965/peripherals-taken.size
+++ b/ci/expected/lm3s6965/peripherals-taken.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4680	      0	      4	   4684	   124c	peripherals-taken

--- a/ci/expected/lm3s6965/pool.size
+++ b/ci/expected/lm3s6965/pool.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6116	      0	   2064	   8180	   1ff4	pool

--- a/ci/expected/lm3s6965/preempt.size
+++ b/ci/expected/lm3s6965/preempt.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5992	      0	     24	   6016	   1780	preempt

--- a/ci/expected/lm3s6965/prio-inversion.size
+++ b/ci/expected/lm3s6965/prio-inversion.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6736	      0	     36	   6772	   1a74	prio-inversion

--- a/ci/expected/lm3s6965/ramfunc.size
+++ b/ci/expected/lm3s6965/ramfunc.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5616	      0	     20	   5636	   1604	ramfunc

--- a/ci/expected/lm3s6965/resource-user-struct.size
+++ b/ci/expected/lm3s6965/resource-user-struct.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5188	      0	     16	   5204	   1454	resource-user-struct

--- a/ci/expected/lm3s6965/shared.size
+++ b/ci/expected/lm3s6965/shared.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5764	      0	     40	   5804	   16ac	shared

--- a/ci/expected/lm3s6965/smallest.size
+++ b/ci/expected/lm3s6965/smallest.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4488	      0	      4	   4492	   118c	smallest

--- a/ci/expected/lm3s6965/spawn.size
+++ b/ci/expected/lm3s6965/spawn.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5268	      0	     16	   5284	   14a4	spawn

--- a/ci/expected/lm3s6965/spawn_arguments.size
+++ b/ci/expected/lm3s6965/spawn_arguments.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   7420	      0	     16	   7436	   1d0c	spawn_arguments

--- a/ci/expected/lm3s6965/spawn_err.size
+++ b/ci/expected/lm3s6965/spawn_err.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5388	      0	     16	   5404	   151c	spawn_err

--- a/ci/expected/lm3s6965/spawn_loop.size
+++ b/ci/expected/lm3s6965/spawn_loop.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5484	      0	     16	   5500	   157c	spawn_loop

--- a/ci/expected/lm3s6965/static-resources-in-divergent.size
+++ b/ci/expected/lm3s6965/static-resources-in-divergent.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   9832	      0	    108	   9940	   26d4	static-resources-in-divergent

--- a/ci/expected/lm3s6965/static-resources-in-init.size
+++ b/ci/expected/lm3s6965/static-resources-in-init.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   6332	      0	     52	   6384	   18f0	static-resources-in-init

--- a/ci/expected/lm3s6965/t-binds.size
+++ b/ci/expected/lm3s6965/t-binds.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4540	      0	      4	   4544	   11c0	t-binds

--- a/ci/expected/lm3s6965/t-cfg-resources.size
+++ b/ci/expected/lm3s6965/t-cfg-resources.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4512	      0	      4	   4516	   11a4	t-cfg-resources

--- a/ci/expected/lm3s6965/t-htask-main.size
+++ b/ci/expected/lm3s6965/t-htask-main.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4548	      0	      4	   4552	   11c8	t-htask-main

--- a/ci/expected/lm3s6965/t-idle-main.size
+++ b/ci/expected/lm3s6965/t-idle-main.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4508	      0	      4	   4512	   11a0	t-idle-main

--- a/ci/expected/lm3s6965/t-late-not-send.size
+++ b/ci/expected/lm3s6965/t-late-not-send.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   4512	      0	      4	   4516	   11a4	t-late-not-send

--- a/ci/expected/lm3s6965/task.size
+++ b/ci/expected/lm3s6965/task.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5860	      0	     24	   5884	   16fc	task

--- a/ci/expected/lm3s6965/wait-queue.size
+++ b/ci/expected/lm3s6965/wait-queue.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   8308	      0	     44	   8352	   20a0	wait-queue

--- a/ci/expected/lm3s6965/zero-prio-task.size
+++ b/ci/expected/lm3s6965/zero-prio-task.size
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+   5516	      0	     20	   5536	   15a0	zero-prio-task

--- a/examples/lm3s6965/Cargo.lock
+++ b/examples/lm3s6965/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtic"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "rtic-common"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -517,7 +517,7 @@ checksum = "d9369355b04d06a3780ec0f51ea2d225624db777acbc60abd8ca4832da5c1a42"
 
 [[package]]
 name = "rtic-macros"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "indexmap",
  "proc-macro-error2",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "rtic-monotonics"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "rtic-sync"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "rtic-time"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -468,7 +468,7 @@ pub enum Commands {
     /// arguments will be passed on
     ///
     /// Example: `cargo xtask size -- -A`
-    Size(Arg),
+    Size(ArgsAndOverwrite),
 
     /// Run examples in QEMU and compare against expected output
     ///
@@ -560,6 +560,19 @@ pub struct QemuAndRun {
     /// This overwrites only missing or mismatching
     #[arg(long)]
     pub overwrite_expected: bool,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct ArgsAndOverwrite {
+    /// If expected output is missing or mismatching, recreate the file
+    ///
+    /// This overwrites only missing or mismatching
+    #[arg(long)]
+    pub overwrite_expected: bool,
+
+    /// Options to pass to `cargo <subcommand>`
+    #[command(subcommand)]
+    pub arguments: Option<ExtraArguments>,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -317,6 +317,7 @@ fn main() -> anyhow::Result<()> {
                 platform,
                 backend,
                 &examples_to_run,
+                args.overwrite_expected,
                 &args.arguments,
             )
         }


### PR DESCRIPTION
- **xtask: size: Store the expected output same as run**
- **ci: Generate and store example filesizes**
