### PR TITLE
Address `clippy::uninlined_format_args`

### DIFF
--- a/rtic-macros/src/codegen/bindings/riscv_slic.rs
+++ b/rtic-macros/src/codegen/bindings/riscv_slic.rs
@@ -81,7 +81,7 @@ pub fn pre_init_preprocessing(app: &mut App, _analysis: &SyntaxAnalysis) -> pars
         .collect::<HashSet<_>>();
 
     for i in 0..soft_priorities.len() {
-        let dispatcher_ident = Ident::new(&format!("__RTICDispatcher{}", i), Span::call_site());
+        let dispatcher_ident = Ident::new(&format!("__RTICDispatcher{i}"), Span::call_site());
         app.args
             .dispatchers
             .insert(dispatcher_ident, Dispatcher { attrs: vec![] });

--- a/rtic-monotonics/build.rs
+++ b/rtic-monotonics/build.rs
@@ -57,7 +57,7 @@ fn stm32() {
                     println!("{}", p.name);
                     let port_letter = p.name.strip_prefix("GPIO").unwrap();
                     for pin_num in 0..16 {
-                        singletons.push(format!("P{}{}", port_letter, pin_num));
+                        singletons.push(format!("P{port_letter}{pin_num}"));
                     }
                 }
 

--- a/rtic/build.rs
+++ b/rtic/build.rs
@@ -13,7 +13,7 @@ fn main() {
         })
         .collect();
     if backends.len() > 1 {
-        panic!("More than one backend feature selected: {:?}", backends);
+        panic!("More than one backend feature selected: {backends:?}");
     }
     let backend = backends.pop().expect("No backend feature selected.");
 
@@ -34,7 +34,7 @@ fn main() {
             println!("cargo:rustc-cfg=feature=\"riscv-slic\"");
         }
         _ => {
-            panic!("Unknown backend feature: {:?}", backend);
+            panic!("Unknown backend feature: {backend:?}");
         }
     }
 


### PR DESCRIPTION
`clippy::uninlined_format_args` was moved to being classified as `style` from its previous classification of `pedantic` in Rust 1.88 (see [clippy changelog](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-188)).

The change is causing CI to fail on `master`, as I've noticed in https://github.com/rtic-rs/rtic/pull/1085.