### PR TITLE
Forward attributes applied to app module

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Added
+
+- Outer attributes applied to RTIC app module are now forwarded to the generated code.
+
 ## [v2.2.0] - 2025-06-22
 
 ### Added

--- a/rtic-macros/src/codegen.rs
+++ b/rtic-macros/src/codegen.rs
@@ -44,12 +44,14 @@ pub fn app(app: &App, analysis: &Analysis) -> TokenStream2 {
     let user_code = &app.user_code;
     let name = &app.name;
     let device = &app.args.device;
+    let attribute_metas = &app.attribute_metas;
 
     let rt_err = util::rt_err_ident();
     let async_limit = bindings::async_prio_limit(app, analysis);
 
     quote!(
         /// The RTIC application module
+        #(#[#attribute_metas])*
         pub mod #name {
             /// Always include the device crate which contains the vector table
             use #device as #rt_err;

--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -1,6 +1,6 @@
 //! Abstract Syntax Tree
 
-use syn::{Attribute, Expr, Ident, Item, ItemUse, Pat, PatType, Path, Stmt, Type};
+use syn::{Attribute, Expr, Ident, Item, ItemUse, Meta, Pat, PatType, Path, Stmt, Type};
 
 use crate::syntax::{backend::BackendArgs, Map};
 
@@ -10,6 +10,9 @@ use crate::syntax::{backend::BackendArgs, Map};
 pub struct App {
     /// The arguments to the `#[app]` attribute
     pub args: AppArgs,
+
+    /// All attributes applied to the `#[app]` module (meta only)
+    pub attribute_metas: Vec<Meta>,
 
     /// The name of the `const` item on which the `#[app]` attribute has been placed
     pub name: Ident,

--- a/rtic-macros/src/syntax/parse/app.rs
+++ b/rtic-macros/src/syntax/parse/app.rs
@@ -531,6 +531,7 @@ impl App {
         }
 
         Ok(App {
+            attribute_metas: input.attribute_metas,
             args,
             name: input.ident,
             init,

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## [Unreleased]
 
+### Changed
+
+- Un-hide lifetimes of output type in `Signal::split` to resolve a new warning.
+
 ## v1.4.0 - 2025-06-22
 
 ### Added

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -48,7 +48,7 @@ impl<T: Copy> Signal<T> {
     }
 
     /// Split the signal into a writer and reader.
-    pub fn split(&self) -> (SignalWriter<T>, SignalReader<T>) {
+    pub fn split(&self) -> (SignalWriter<'_, T>, SignalReader<'_, T>) {
         (SignalWriter { parent: self }, SignalReader { parent: self })
     }
 }

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -20,6 +20,10 @@ Example:
 
 ## [Unreleased]
 
+### Added
+
+- Outer attributes applied to RTIC app module are now forwarded to the generated code.
+
 ## [v2.2.0] - 2025-06-22
 
 ### Added

--- a/rtic/ui/inner_attribute.rs
+++ b/rtic/ui/inner_attribute.rs
@@ -1,0 +1,21 @@
+#![no_main]
+#![deny(unfulfilled_lint_expectations)]
+
+#[rtic::app(device = lm3s6965)]
+mod app {
+    #![expect(while_true)]
+    
+    #[shared]
+    struct Shared {
+        #[unsafe(link_section = ".custom_section")]
+        foo: (),
+    }
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_cx: init::Context) -> (Shared, Local) {
+        (Shared { foo: () }, Local {})
+    }
+}

--- a/rtic/ui/inner_attribute.stderr
+++ b/rtic/ui/inner_attribute.stderr
@@ -1,0 +1,11 @@
+error: this lint expectation is unfulfilled
+ --> ui/inner_attribute.rs:6:15
+  |
+6 |     #![expect(while_true)]
+  |               ^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> ui/inner_attribute.rs:2:9
+  |
+2 | #![deny(unfulfilled_lint_expectations)]
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rtic/ui/outer_attribute.rs
+++ b/rtic/ui/outer_attribute.rs
@@ -1,0 +1,20 @@
+#![no_main]
+#![deny(unfulfilled_lint_expectations)]
+
+#[rtic::app(device = lm3s6965)]
+#[expect(while_true)]
+mod app {
+    #[shared]
+    struct Shared {
+        #[unsafe(link_section = ".custom_section")]
+        foo: (),
+    }
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_cx: init::Context) -> (Shared, Local) {
+        (Shared { foo: () }, Local {})
+    }
+}

--- a/rtic/ui/outer_attribute.stderr
+++ b/rtic/ui/outer_attribute.stderr
@@ -1,0 +1,11 @@
+error: this lint expectation is unfulfilled
+ --> ui/outer_attribute.rs:5:10
+  |
+5 | #[expect(while_true)]
+  |          ^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> ui/outer_attribute.rs:2:9
+  |
+2 | #![deny(unfulfilled_lint_expectations)]
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rtic/ui/task-priority-too-high.stderr
+++ b/rtic/ui/task-priority-too-high.stderr
@@ -1,5 +1,5 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation panicked: Maximum priority used by interrupt vector 'I2C0' is more than supported by hardware
  --> ui/task-priority-too-high.rs:3:1
   |
 3 | #[rtic::app(device = lm3s6965)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Maximum priority used by interrupt vector 'I2C0' is more than supported by hardware
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `app::main::_` failed here


### PR DESCRIPTION
Instead of ignoring additional attributes applied to the `#[app]` module, we can forward them to the generated code to make the `mod app` act more like a normal `app`.

Also fixing some unrelated changes tests that have come as a result of updates to rustc stable, in separate commits. I'm trying my best to figure out in which version they stopped compiling, but can't seem to get TryBuild to use a different version of `cargo`.