### PR TITLE
ci: Audit-check: create Cargo.lock before audit-check

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -2,11 +2,13 @@ name: Security audit
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - run: cargo generate-lockfile # create Cargo.lock
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allow on demand action checks

use latest actions/checkout

---

https://github.com/rtic-rs/rtic/pull/1080 switched to using rustsec/audit-check but didn't setup the
Cargo.lock file. This action has been failing for
three months.

https://github.com/rtic-rs/rtic/actions/workflows/audit.yaml

---

https://github.com/rustsec/audit-check/pull/39
describes how a missing Cargo.lock will be missing in library crates.

---

Running in my fork worked: https://github.com/becomingwisest/rtic/actions/runs/17673551127

1 unmaintained crate was found: [paste: RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436.html)