### PR TITLE
rtic & rtic-macros: release v2.3.0

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -5,7 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
-## [Unreleased]
+## Unreleased
+
+## [v2.3.0] - 2025-09-17
 
 ### Fixed
 
@@ -27,7 +29,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [v2.1.3] - 2025-06-08
 
-### Changed 
+### Changed
 
 - Unstable support for ESP32-C6
 - Adapt `slic` backends to new version with `mecall`

--- a/rtic-macros/Cargo.toml
+++ b/rtic-macros/Cargo.toml
@@ -22,7 +22,7 @@ name = "rtic-macros"
 readme = "../README.md"
 repository = "https://github.com/rtic-rs/rtic"
 
-version = "2.2.0"
+version = "2.3.0"
 
 [package.metadata.docs.rs]
 features = ["test-template"]

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -20,6 +20,8 @@ Example:
 
 ## [Unreleased]
 
+## [v2.3.0] - 2025-09-17
+
 ### Added
 
 - Outer attributes applied to RTIC app module are now forwarded to the generated code.

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -16,7 +16,7 @@ name = "rtic"
 readme = "../README.md"
 repository = "https://github.com/rtic-rs/rtic"
 
-version = "2.2.0"
+version = "2.3.0"
 
 [package.metadata.docs.rs]
 features = ["thumbv7-backend"]
@@ -31,7 +31,7 @@ esp32c6 = { version = "0.21.0", optional = true }
 riscv = { version = "0.16.0", optional = true }
 cortex-m = { version = "0.7.0", optional = true }
 portable-atomic = { version = "1", default-features = false }
-rtic-macros = { path = "../rtic-macros", version = "=2.2.0" }
+rtic-macros = { path = "../rtic-macros", version = "=2.3.0" }
 rtic-core = "1"
 critical-section = "1"
 


### PR DESCRIPTION
Not sure how keen we are on dropping a release just like this, but I figured I'd open a PR in case we feel inclined to :) Seems like a minor version bump to me: backwards-compatible added functionality.