### PR TITLE
Add links to changelogs

### DIFF
--- a/rtic-common/CHANGELOG.md
+++ b/rtic-common/CHANGELOG.md
@@ -25,8 +25,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
-## [v1.0.1]
+## [v1.0.1](https://github.com/rtic-rs/rtic/commit/2b2208e217a96086696bd6f36cff2a6cd4c4ac9f)
 
 - `portable-atomic` used as a drop in replacement for `core::sync::atomic` in code and macros. `portable-atomic` imported with `default-features = false`, as we do not require CAS.
 
-## [v1.0.0] - 2023-05-31
+## [v1.0.0](https://github.com/rtic-rs/rtic/commit/e65e532c2a342f77080ac6fc8e5be11aa7d82575)(https://github.com/rtic-rs/rtic/commit/c3884e212c36d2a9cf260b1d9ae37c92b91ea73d) - 2023-05-31

--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -21,7 +21,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Support Rust edition 2024 `unsafe(link_section)` attribute
 
-## [v2.1.3] - 2025-06-08
+## [v2.1.3](https://github.com/rtic-rs/rtic/commit/95616b3c59e0d57afc8fb569458a33973beeaf54) - 2025-06-08
 
 ### Changed 
 
@@ -42,7 +42,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Fix interrupt handlers when targeting esp32c3 and using latest version of esp-hal
 - Do not limit async priority with `NVIC_PRIO_BITS` when targeting esp32c3
 
-## [v2.1.0] - 2024-02-27
+## [v2.1.0](https://github.com/rtic-rs/rtic/commit/0b365f03eb77302663b751305aac7641b2721eb3) - 2024-02-27
 
 ### Added
 
@@ -54,7 +54,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Upgraded from syn 1.x to syn 2.x
 
-## [v2.0.1] - 2023-07-25
+## [v2.0.1](https://github.com/rtic-rs/rtic/commit/0228350ef4758c45623e325c41116720bbc2b30a) - 2023-07-25
 
 ### Added
 
@@ -64,6 +64,6 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Support new TAIT syntax requirement.
 
-## [v2.0.0] - 2023-05-31
+## [v2.0.0](https://github.com/rtic-rs/rtic/commit/c3884e212c36d2a9cf260b1d9ae37c92b91ea73d) - 2023-05-31
 
 - Initial v2 release

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -21,7 +21,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - `SYSTIMER` based monotonic for the ESP32-C6
 
-## v2.0.3 - 2024-10-23
+## [v2.0.3](https://github.com/rtic-rs/rtic/commit/d251ba717393a73e9ea26a34fe738e3baec477d2) - 2024-10-23
 
 ### Added
 
@@ -37,7 +37,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - STM32: Make initialization more deterministic
 - STM32: Fix race condition that caused missed interrupts
 
-## v2.0.2 - 2024-07-05
+## [v2.0.2](https://github.com/rtic-rs/rtic/commit/f925cbe5061ec4ade77935de4a0a790e7fc3ba7c) - 2024-07-05
 
 ### Added
 - `SYSTIMER` based monotonic for the ESP32-C3
@@ -46,13 +46,13 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Fix `stm32` monotonic for timer peripherals with only two clock compare modules
 
-## v2.0.1 - 2024-06-02
+## [v2.0.1](https://github.com/rtic-rs/rtic/commit/689c4a068eddfe32956c1975cdc241b26d1751da) - 2024-06-02
 
 ### Changed
 
 - Make monotonics created with their respective macros public
 
-## v2.0.0 - 2024-05-29
+## [v2.0.0](https://github.com/rtic-rs/rtic/commit/8c23e178f3838bcdd13662a2ffefd39ec144e869) - 2024-05-29
 
 ### Changed
 
@@ -63,13 +63,13 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Removed unused `rust-toolchain.toml`
 - RP2040 PAC 0.6 support
 
-## v1.5.0 - 2024-01-10
+## [v1.5.0](https://github.com/rtic-rs/rtic/commit/f69ecb05a95fd7c2906d060c1548291052dba6bd) - 2024-01-10
 
 ### Changed
 
 - Using `embedded-hal` 1.0.
 
-## v1.4.1 - 2023-12-06
+## [v1.4.1](https://github.com/rtic-rs/rtic/commit/e53624c26396019849e10374eacaf416b11c4e5a) - 2023-12-06
 
 ### Fixed
 
@@ -79,7 +79,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Add internal counter integrity check to all half-period based monotonics.
 - Apply race condition fixes from `rtic-time`.
 
-## v1.4.0 - 2023-12-04
+## [v1.4.0](https://github.com/rtic-rs/rtic/commit/ea8de913d7e7265b13edee779e4ab614a227bef2) - 2023-12-04
 
 ### Fixed
 
@@ -89,7 +89,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Bump `rtic-time`
 
-## v1.3.0 - 2023-11-08
+## [v1.3.0](https://github.com/rtic-rs/rtic/commit/4425b76c6f25a782ea2c473adfa99aec1e5795ac) - 2023-11-08
 
 ### Added
 
@@ -100,20 +100,20 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Fix STM32 rollover race condition
 - Fix STM32 support for other chip families
 
-## v1.2.0 - 2023-09-19
+## [v1.2.0](https://github.com/rtic-rs/rtic/commit/3b8d787a917a7a39b28bea85ba2b3a86539e0852) - 2023-09-19
 
 ### Added
 
 - STM32 support.
 - `embedded-hal` 1.0.0-rc.1 `DelayUs` support
 
-## v1.1.0 - 2023-08-29
+## [v1.1.0](https://github.com/rtic-rs/rtic/commit/adfe33f5976991a2d957c9e5f209904d46eb934a) - 2023-08-29
 
 ### Added
 
 - Feature `systick-64bit` to get 64-bit backed `TimerInstantU64` instead of `TimerInstantU32` from the SysTick-based monotonic timer
 
-## v1.0.1 - 2023-08-20
+## [v1.0.1](https://github.com/rtic-rs/rtic/commit/df66163aceb1128686e9efcf77d6e3e8520f86b3) - 2023-08-20
 
 ### Added
 
@@ -130,4 +130,4 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Unmask the `rp2040` interrupt
 - Use `$crate` and fully qualified paths in macros
 
-## v1.0.0 - 2023-05-31
+## [v1.0.0](https://github.com/rtic-rs/rtic/commit/c3884e212c36d2a9cf260b1d9ae37c92b91ea73d) - 2023-05-31

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -11,7 +11,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 - Un-hide lifetimes of output type in `Signal::split` to resolve a new warning.
 
-## v1.4.0 - 2025-06-22
+## [v](https://github.com/rtic-rs/rtic/commit/fe77b4538d6cd506d1a18bdc9e17216dc61881db)1.4.0 - 2025-06-22
 
 ### Added
 
@@ -30,14 +30,14 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - Don't force `Signal` import when using `make_signal` macro
 - Update `make_signal`'s documentation to match `make_channel`'s
 
-## v1.3.2 - 2025-03-16
+## [v1.3.2](https://github.com/rtic-rs/rtic/commit/daff0c2913ba5c8c3975313314e531e00a620732) - 2025-03-16
 
 ### Fixed
 
 - Improve handling of free slots for `send` by explicitly writing the free slot to the awoken future.
 - Fix all known instances of #780
 
-## v1.3.1 - 2025-03-12
+## [v1.3.1](https://github.com/rtic-rs/rtic/commit/bac77de9bc5249a8d4e34c816bb94f5945fb1f58) - 2025-03-12
 
 ### Fixed
 
@@ -45,7 +45,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 [#780]: https://github.com/rtic-rs/rtic/issues/780
 
-## v1.3.0 - 2024-05-01
+## [v1.3.0](https://github.com/rtic-rs/rtic/commit/4a23c8d6da918b2ddd5a6b694b584fd2737833bb) - 2024-05-01
 
 ### Changed
 
@@ -57,7 +57,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - `defmt v0.3` derives added and forwarded to `embedded-hal(-x)` crates.
 - signal structure
 
-## v1.2.0 - 2024-01-10
+## [v1.2.0](https://github.com/rtic-rs/rtic/commit/f69ecb05a95fd7c2906d060c1548291052dba6bd) - 2024-01-10
 
 ### Changed
 
@@ -67,35 +67,35 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 - `make_channel` now accepts `Type` expressions instead of only `TypePath` expressions.
 
-## v1.1.1 - 2023-12-04
+## [v1.1.1](https://github.com/rtic-rs/rtic/commit/1622f6b953c93c3a680769636b60733f281f1ac0) - 2023-12-04
 
 ### Fixed
 
 - Fix features for `docs.rs`
 
-## v1.1.0 - 2023-12-04
+## [v1.1.0](https://github.com/rtic-rs/rtic/commit/ea8de913d7e7265b13edee779e4ab614a227bef2) - 2023-12-04
 
 ### Added
 
 - `arbiter::spi::ArbiterDevice` for sharing SPI buses using `embedded-hal-async` traits.
 - `arbiter::i2c::ArbiterDevice` for sharing I2C buses using `embedded-hal-async` traits.
 
-## v1.0.3
+## [v1.0.3](https://github.com/rtic-rs/rtic/commit/2b2208e217a96086696bd6f36cff2a6cd4c4ac9f)
 
 - `portable-atomic` used as a drop in replacement for `core::sync::atomic` in code and macros. `portable-atomic` imported with `default-features = false`, as we do not require CAS.
 
-## v1.0.2 - 2023-08-29
+## [v1.0.2](https://github.com/rtic-rs/rtic/commit/adfe33f5976991a2d957c9e5f209904d46eb934a) - 2023-08-29
 
 ### Fixed
 
 - `make_channel` no longer requires the user crate to have `critical_section` in scope
 
-## v1.0.1 - 2023-06-14
+## [v1.0.1](https://github.com/rtic-rs/rtic/commit/db18c00c00deb146478de1b0f94f8181300c47ce) - 2023-06-14
 
 ### Fixed
 
 - `make_channel` could be UB
 
-## v1.0.0 - 2023-05-31 - yanked
+## [v1.0.0](https://github.com/rtic-rs/rtic/commit/c3884e212c36d2a9cf260b1d9ae37c92b91ea73d) - 2023-05-31 - yanked
 
 - Initial release

--- a/rtic-time/CHANGELOG.md
+++ b/rtic-time/CHANGELOG.md
@@ -7,13 +7,13 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
-## v2.0.1 - 2025-06-22
+## [v](https://github.com/rtic-rs/rtic/commit/306aa47170fd59369b7a184924e287dc3706d64d)2.0.1 - 2025-06-22
 
 ### Changed
 
 - Replace `async` implementations of `delay`/`delay_until`/`timeout`/`timeout_at` with structs to reduce memory usage.
 
-## v2.0.0 - 2024-05-29
+## [v2.0.0](https://github.com/rtic-rs/rtic/commit/8c23e178f3838bcdd13662a2ffefd39ec144e869) - 2024-05-29
 
 ### Added
 
@@ -30,13 +30,13 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Docs: Rename `DelayUs` to `DelayNs` in docs.
 
-## v1.3.0 - 2024-01-10
+## [v1.3.0](https://github.com/rtic-rs/rtic/commit/f69ecb05a95fd7c2906d060c1548291052dba6bd) - 2024-01-10
 
 ### Changed
 
 - Using `embedded-hal` 1.0.
 
-## v1.2.0 - 2023-12-06
+## [v1.2.0](https://github.com/rtic-rs/rtic/commit/f377471e440d8be0b2f9e9c8877ed015f62dc19e) - 2023-12-06
 
 ### Changed
 
@@ -48,7 +48,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Fix race condition in `half_period_counter::calculate_now`.
   This sadly required a minor API change.
 
-## v1.1.0 - 2023-12-04
+## [v1.1.0](https://github.com/rtic-rs/rtic/commit/c227a71d243db6d539f3c64e3b4bb1b3ab282693) - 2023-12-04
 
 ### Added
 
@@ -62,4 +62,4 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - **Soundness fix:** `TimerQueue` did not wait long enough in `Duration` based delays. Fixing this sadly required adding a `const TICK_PERIOD` to the `Monotonic` trait, which requires updating all existing implementations.
 - If the queue was non-empty and a new instant was added that was earlier than `head`, then the queue would no pend the monotonic handler. This would cause the new `head` to be dequeued at the wrong time.
 
-## v1.0.0 - 2023-05-31
+## [v1.0.0](https://github.com/rtic-rs/rtic/commit/c3884e212c36d2a9cf260b1d9ae37c92b91ea73d) - 2023-05-31

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -30,7 +30,7 @@ Example:
 
 - Added public `waker` constructor to the executor.
 
-## [v2.1.3] - 2025-06-08
+## [v2.1.3](https://github.com/rtic-rs/rtic/commit/95616b3c59e0d57afc8fb569458a33973beeaf54) - 2025-06-08
 
 ### Fixed
 
@@ -49,7 +49,7 @@ Example:
 - Unstable support for ESP32-C6
 - Support for RISC-V targets compatible with `riscv-slic` using machine-level environment call exceptions.
 
-## [v2.1.2] - 2024-12-06
+## [v2.1.2](https://github.com/rtic-rs/rtic/commit/b41a10e794261e1539cd571aab00fca40568ba87) - 2024-12-06
 
 ### Changed
 
@@ -60,13 +60,13 @@ Example:
 - Use `riscv-slic` from `crates.io`
 - Remove unused dependency `rtic-monotonics`
 
-## [v2.1.1] - 2024-03-13
+## [v2.1.1](https://github.com/rtic-rs/rtic/commit/82cf534f5db00a2b00565172800f84a434edcb37) - 2024-03-13
 
 ### Fixed
 
 - **Soundness fix:** `thumbv6` was subject to race in source mask.
 
-## [v2.1.0] - 2024-02-27
+## [v2.1.0](https://github.com/rtic-rs/rtic/commit/0b365f03eb77302663b751305aac7641b2721eb3) - 2024-02-27
 
 ### Added
 
@@ -83,7 +83,7 @@ Example:
 
 - RTIC v2 now works on stable.
 
-## [v2.0.1] - 2023-07-25
+## [v2.0.1](https://github.com/rtic-rs/rtic/commit/0228350ef4758c45623e325c41116720bbc2b30a) - 2023-07-25
 
 ### Added
 
@@ -99,7 +99,7 @@ Example:
 - Moved `cortex-m`-related utilities from `rtic/lib.rs` to `rtic/export.rs`
 - Make async task priorities start at 0, instead of 1, to always start at the lowest priority
 
-## [v2.0.0] - 2023-05-31
+## [v2.0.0](https://github.com/rtic-rs/rtic/commit/c3884e212c36d2a9cf260b1d9ae37c92b91ea73d) - 2023-05-31
 
 - v2 is a massive change, refer to the book for more details
 


### PR DESCRIPTION
Instead of having bare, link-less references in our markdown files, we can have all of them! (And perhaps become better at linking new releases?)

Also, please squash this PR, I've just added each commit separately so it's not as messy.

Script:

<details>
<summary>Awful shell script</summary>

```bash
#!/bin/bash

# set -x

get_version() {
    revision="$1"
    file="$2"

    git show $revision:"$file" | grep "version =" | head -n 1 | cut -d ' ' -f3 | cut -d '"' -f2
}

get_commit() {
    revision="$1"
    file="$2"

    git blame --abbrev=40 $revision -- "$file" | grep "version = " | head -n 1 | cut -d ' ' -f1
}

file="$1"
changelog="$2"
current_commit=$(get_commit HEAD "$file")
current_version=$(get_version $current_commit "$file")

echo "Commit for v$current_version: $current_commit"

while [ $(git show $current_commit~1:"$file" > /dev/null 2>&1; echo $?) = "0" ]; do
    current_commit=$(get_commit $current_commit~1 "$file")
    current_version=$(get_version $current_commit "$file")

    tag=$(git describe $current_commit)
    echo "Commit for v$current_version: $current_commit."
    escaped_version=$(echo -n "$current_version" | sed "s/\\./\\\\./g")
    url="https://github.com/rtic-rs/rtic/commit/$current_commit"
    # I hate it, but it works :)
    sed -E -i "s@## (\\[v$escaped_version\\]|v$escaped_version)(.*)\$@## [v$current_version]($url)\\2@g" "$changelog"
done

```