### PR TITLE
trampoline functionalty

### DIFF
--- a/ci/expected/lm3s6965/trampoline.run
+++ b/ci/expected/lm3s6965/trampoline.run
@@ -1,0 +1,6 @@
+gpioa lock
+gpioa unlock
+SysTick start
+idle
+SysTick start
+idle end

--- a/examples/lm3s6965/examples/trampoline.rs
+++ b/examples/lm3s6965/examples/trampoline.rs
@@ -1,0 +1,65 @@
+//! examples/bouncy_trampoline.rs
+
+#![no_std]
+#![no_main]
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+
+use panic_semihosting as _;
+
+// `examples/bouncy_trampoline.rs` testing trampoline feature 
+#[rtic::app(device = lm3s6965)]
+mod app {
+    use cortex_m_semihosting::{debug, hprintln};
+    use lm3s6965::Interrupt;
+
+    #[shared]
+    struct Shared {
+        h_priority: u8,
+    }
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        // Trigger SW0 interrupt to test NMI preemption
+        rtic::pend(Interrupt::GPIOA);
+        (Shared { h_priority: 0 }, Local {})
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        hprintln!("idle");
+
+        // pend another interrupt to test trampoline
+        cortex_m::peripheral::SCB::set_pendst();   
+        hprintln!("idle end");
+        
+        debug::exit(debug::EXIT_SUCCESS);
+        loop {
+            cortex_m::asm::wfi();
+        }
+    }
+
+    #[task(binds = SysTick, trampoline = GPIOC, priority = 2, shared = [h_priority])]
+    fn sys_tick(_: sys_tick::Context) {
+        hprintln!("SysTick start");
+    }
+
+    #[task(binds = GPIOA, priority = 1, shared = [h_priority])]
+    fn gpioa(mut ctx: gpioa::Context) {
+        ctx.shared.h_priority.lock(|_| {
+            hprintln!("gpioa lock");
+            cortex_m::peripheral::SCB::set_pendst();   
+            cortex_m::asm::delay(100_000_000);
+            hprintln!("gpioa unlock");
+        });
+    }
+
+    #[task(binds = GPIOB, priority = 3, shared = [h_priority])]
+    fn high_priority_task(_: high_priority_task::Context) {
+        hprintln!("High priority task");
+    }
+}

--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -10,6 +10,9 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Added
 
 - Outer attributes applied to RTIC app module are now forwarded to the generated code.
+- Added the trampoline argument to hardware tasks which lets the given trampoline execute the code, and the bind only pends the trampoline.
+-Cortex-m source masking returns an error if a non maskable interrupt is used as a bind without a trampoline. 
+- removed leading space ``task-reference-in-spawner.stderr`` as to make ci pass.
 
 ## [v2.2.0] - 2025-06-22
 

--- a/rtic-macros/src/codegen/bindings/cortex.rs
+++ b/rtic-macros/src/codegen/bindings/cortex.rs
@@ -319,13 +319,13 @@ pub fn architecture_specific_analysis(app: &App, _: &SyntaxAnalysis) -> parse::R
         .filter(|prio| *prio > 0)
         .collect::<HashSet<_>>();
 
-    let need = priorities.len();
+    let need_software = priorities.len();
     let given = app.args.dispatchers.len();
-    if need > given {
+    if need_software > given {
         let s = {
             format!(
                 "not enough interrupts to dispatch \
-                    all software tasks (need: {need}; given: {given})"
+                    all software tasks (need: {need_software}; given: {given})"
             )
         };
 

--- a/rtic-macros/src/codegen/bindings/cortex.rs
+++ b/rtic-macros/src/codegen/bindings/cortex.rs
@@ -376,7 +376,10 @@ pub fn architecture_specific_analysis(app: &App, _: &SyntaxAnalysis) -> parse::R
     }
 
     // Check that a exception is not used with shared resources
-    // TODO provide warning when a exception is used with source masking since it then ignores locks in priority ceilings
+    // TODO This does not stop priority inversion in source masking if the
+    // exception does not use shared resources. We do currently allow this,
+    // since it does not corrupt data, but it may be worth reconsidering this
+    // decision.
     #[cfg(feature = "cortex-m-source-masking")]
     for (name, task) in &app.hardware_tasks {
         if is_exception(name) && !app.shared_resources.is_empty(){
@@ -390,7 +393,8 @@ pub fn architecture_specific_analysis(app: &App, _: &SyntaxAnalysis) -> parse::R
             } else {
                 return Err(parse::Error::new(
                     name.span(),
-                    "cannot use exceptions with shared resources as hardware tasks when using source masking, consider adding the trampoline attribute",
+                    "cannot use exceptions with shared resources as hardware tasks when using \
+                    source masking, consider adding the trampoline attribute",
                 ));
             }
         }

--- a/rtic-macros/src/codegen/hardware_tasks.rs
+++ b/rtic-macros/src/codegen/hardware_tasks.rs
@@ -38,10 +38,8 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
                 #(#cfgs)*
                 #(#config)*
                 unsafe fn #symbol() {
-                    info!("Pend trampoline");
                     use #rt_err::Interrupt;
                     rtic::pend(Interrupt::#trampoline_symbol);
-                    info!("Exit trampoline handler");
                 }
 
                 #[allow(non_snake_case)]

--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -298,6 +298,9 @@ pub struct HardwareTaskArgs {
     /// The interrupt or exception that this task is bound to
     pub binds: Ident,
 
+    /// if set the bind would trampoline with the given interrupt handler
+    pub trampoline: Option<Ident>,
+
     /// The priority of this task
     pub priority: u8,
 

--- a/rtic-macros/src/syntax/parse.rs
+++ b/rtic-macros/src/syntax/parse.rs
@@ -193,6 +193,7 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
         }
 
         let mut binds = None;
+        let mut trampoline = None;
         let mut priority = None;
         let mut shared_resources = None;
         let mut local_resources = None;
@@ -223,7 +224,21 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
                     let ident = input.parse()?;
 
                     binds = Some(ident);
-                }
+                },
+
+                "trampoline" => {
+                    if trampoline.is_some() {
+                        return Err(parse::Error::new(
+                            ident.span(),
+                            "argument appears more than once",
+                        ));
+                    }
+
+                    // Parse identifier name
+                    let ident: Ident = input.parse()?;
+
+                    trampoline = Some(ident);
+                },
 
                 "priority" => {
                     if priority.is_some() {
@@ -277,8 +292,8 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
                     local_resources = Some(util::parse_local_resources(input)?);
                 }
 
-                _ => {
-                    return Err(parse::Error::new(ident.span(), "unexpected argument"));
+                a => {
+                    return Err(parse::Error::new(ident.span(), format!("unexpected argument {}", a)));
                 }
             }
 
@@ -308,6 +323,7 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
                 priority,
                 shared_resources,
                 local_resources,
+                trampoline,
             })
         } else {
             // Software tasks start at idle priority

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -5,10 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
+
+- changed (sysclk % timer_hz) == 0 to sysclk.is_multiple_of(timer_hz) to make clippy happy as required to CI.
+  It is unclear why this was not already implemented since the current version does not pass CI.
+
+### Changed
+
 - Panic if STM32 prescaler value would overflow
+- Changed modulo to ``is_multiple_of()``, to make clippy happy
 
 ## v2.1.0 - 2025-06-22
 

--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -74,7 +74,7 @@ impl SystickBackend {
     /// Use the prelude macros instead.
     pub fn _start(mut systick: SYST, sysclk: u32, timer_hz: u32) {
         assert!(
-            (sysclk % timer_hz) == 0,
+            sysclk.is_multiple_of(timer_hz),
             "timer_hz cannot evenly divide sysclk! Please adjust the timer or sysclk frequency."
         );
         let reload = sysclk / timer_hz - 1;

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -23,6 +23,7 @@ Example:
 ### Added
 
 - Outer attributes applied to RTIC app module are now forwarded to the generated code.
+- Added trampoline functionality
 
 ### Changed
 

--- a/rtic/ui/task-reference-in-spawn.stderr
+++ b/rtic/ui/task-reference-in-spawn.stderr
@@ -1,7 +1,7 @@
 error[E0521]: borrowed data escapes outside of function
   --> ui/task-reference-in-spawn.rs:3:1
    |
-3  | #[rtic::app(device = lm3s6965, dispatchers = [SSI0, QEI0, GPIOA])]
+ 3 | #[rtic::app(device = lm3s6965, dispatchers = [SSI0, QEI0, GPIOA])]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | `_0` is a reference that is only valid in the function body


### PR DESCRIPTION
### Trampoline Feature for Hardware Tasks

This pull request introduces a new **trampoline** feature for hardware tasks in RTIC.
It allows an interrupt handler to pend another interrupt (the *trampoline*), which then executes the actual task code.
This approach improves interrupt handling flexibility and source masking safety (as some exceptions cannot be masked through the NVIC).

The implementation includes changes to parsing, code generation, and error checking for correct usage.
It also includes a small CI fix and a minor clippy compliance improvement to the `rtic-monotonics` crate.

---

### Overview

**Trampoline Behavior**

Normally, when using the source masking backend, we expect that a lower-priority exception waits until the higher-priority task finishes:

```text
  lock     |     _______________
           |     |             |
  exception|     |             | =========
  task     | ____| _  _  _  _  |_
           |_______________________________
```

However, because we artificially raise priority by disabling interrupts (not exceptions), the effective task priority remains unchanged.
This means that lower-priority exceptions can still preempt the task:

```text
  lock     |     ______          ______
           |     |                    |
  exception|     |     ==========     | 
  task     | ____| _  _          _  _ |_
           |_______________________________
```

The trampoline mechanism solves this by pended interrupts that are properly masked by the source masking backend, preserving the Stack Resource Policy (SRP):

```text
  lock     |     ______      ______
           |     |                |
  exception|     |     =pend=     | ~~trampoline irq~~
  task     | ____| _  _      _  _ |_
           |___________________________________________
```

As illustrated, there is a brief priority inversion when pended, but since no critical section is executed during this window, it is not problematic.
We also do not enforce a trampoline when shared resources are not used — these cases still involve a minor priority inversion, but since shared data is untouched, this trade-off was accepted.

For more discussion, see [issue #1088](https://github.com/rtic-rs/rtic/issues/1088).

---

### Implementation Details

* Added support for the `trampoline` argument in hardware task definitions, allowing an interrupt handler to pend another interrupt that executes the task logic.
  [[1]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-b6dc308038f110374a277cf42acfb20d19f30bca1cf30e7bd41528e465030e93R227-R242)
  [[2]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-34953ff60f9179b03ac164a501e3396172b7e3c7c3831c58b8b895beca7925f1R301-R303)
* Updated code generation: when a trampoline is specified, the original interrupt handler only pends the trampoline, which then runs the user’s task code.
  [[1]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-20d738b7b62f50c8c036ade301eaa17e9c66da51fccca21d539bcb444fb24c64R28-R50)
  [[2]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-20d738b7b62f50c8c036ade301eaa17e9c66da51fccca21d539bcb444fb24c64R61-L54)
* Improved source masking logic to account for trampolines and added checks preventing illegal combinations of exceptions, trampolines, and shared resources.
  [[1]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-d5902ea97b19f8ce617060fd709d3e5bce97f124ab11c4c86dc1ab6869c66354L105-R118)
  [[2]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-d5902ea97b19f8ce617060fd709d3e5bce97f124ab11c4c86dc1ab6869c66354R257-R268)
  [[3]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-d5902ea97b19f8ce617060fd709d3e5bce97f124ab11c4c86dc1ab6869c66354R378-R402)

---

### Documentation and Changelog Updates

* Updated changelogs to include the trampoline feature and its interaction with source masking.
  [[1]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-2687262b53a875baa24bac87b2b1551239b8726f3e871a591c61c64b5e139a36R13-R15)
  [[2]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-eb5b7735d327102d329bd71086282b67b4f503c11238bfa3e92e22118b7a76f9R26)

---

### Miscellaneous Improvements

* Changed modulo operations to `is_multiple_of()` in `rtic-monotonics` for clippy compliance.
  [[1]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-b6cbf6dc4cb3d0b823e54ddeb94539639d57a6bcbea7863d36d7c074c7d89cbbL8-R18)
  [[2]](https://github.com/rtic-rs/rtic/pull/1106/files#diff-1ea01758c49cc52a84867079df6484f9af8308985863b4c3a2038cd7fba92ad9L77-R77)
* Fixed a CI issue caused by a leading space in a test output file.

---

### Summary

These changes collectively enhance the flexibility and safety of interrupt handling in RTIC while improving CI reliability and code linting compliance.
