### PR TITLE
Change stm32 TIM5 from u16 to u32

### DIFF
--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -365,7 +365,7 @@ make_timer!(Tim3Backend, TIM3, u16, TIMER3_OVERFLOWS, TIMER3_TQ);
 make_timer!(Tim4Backend, TIM4, u16, TIMER4_OVERFLOWS, TIMER4_TQ);
 
 #[cfg(feature = "stm32_tim5")]
-make_timer!(Tim5Backend, TIM5, u16, TIMER5_OVERFLOWS, TIMER5_TQ);
+make_timer!(Tim5Backend, TIM5, u32, TIMER5_OVERFLOWS, TIMER5_TQ);
 
 #[cfg(feature = "stm32_tim15")]
 make_timer!(Tim15Backend, TIM15, u16, TIMER15_OVERFLOWS, TIMER15_TQ);


### PR DESCRIPTION
I noticed that the first overflow ISR was corrupting the time on a G474 when using TIM5 as a monotonic.

All stm32 with TIM5 are 32bit timers to the best of my knowledge. This changes the type from u16 to u32 which has resolved the issue.