### PR TITLE
Fix warnings caused by new lints introduced in 1.90

### DIFF
--- a/rtic-monotonics/src/systick.rs
+++ b/rtic-monotonics/src/systick.rs
@@ -74,7 +74,7 @@ impl SystickBackend {
     /// Use the prelude macros instead.
     pub fn _start(mut systick: SYST, sysclk: u32, timer_hz: u32) {
         assert!(
-            (sysclk % timer_hz) == 0,
+            sysclk.is_multiple_of(timer_hz),
             "timer_hz cannot evenly divide sysclk! Please adjust the timer or sysclk frequency."
         );
         let reload = sysclk / timer_hz - 1;

--- a/rtic/ui/task-reference-in-spawn.stderr
+++ b/rtic/ui/task-reference-in-spawn.stderr
@@ -1,7 +1,7 @@
 error[E0521]: borrowed data escapes outside of function
   --> ui/task-reference-in-spawn.rs:3:1
    |
-3  | #[rtic::app(device = lm3s6965, dispatchers = [SSI0, QEI0, GPIOA])]
+ 3 | #[rtic::app(device = lm3s6965, dispatchers = [SSI0, QEI0, GPIOA])]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | `_0` is a reference that is only valid in the function body


### PR DESCRIPTION
Fixes the occurrence of `clippy::manual_is_multiple_of` in our codebase, and the new formatting of some errors.

Should we pin the rust version to `1.90`? If we pin `stable` and want to rely on denying warnings, breakage like this can occur again in the future.