### PR TITLE
chore: replace deprecated `bare-metal` with `critical-section`

### DIFF
--- a/book/en/src/by-example/app_init.md
+++ b/book/en/src/by-example/app_init.md
@@ -5,7 +5,7 @@ signature `fn(init::Context) -> (Shared, Local)`, where `Shared` and `Local` are
 
 The `init` task executes after system reset, [after an optionally defined `pre-init` code section][^pre-init] and an always occurring internal RTIC initialization.
 
-The `init` and optional `pre-init` tasks runs _with interrupts disabled_ and have exclusive access to Cortex-M (the `bare_metal::CriticalSection` token is available as `cs`).
+The `init` and optional `pre-init` tasks runs _with interrupts disabled_ and have exclusive access to Cortex-M (the `critical_section::CriticalSection` token is available as `cs`).
 
 Device specific peripherals are available through the `core` and `device` fields of `init::Context`.
 

--- a/examples/lm3s6965/Cargo.lock
+++ b/examples/lm3s6965/Cargo.lock
@@ -21,12 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,7 +53,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
- "bare-metal 0.2.5",
+ "bare-metal",
  "bitfield",
  "critical-section",
  "embedded-hal 0.2.7",
@@ -271,6 +265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,7 +463,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "rtic"
 version = "2.2.0"
 dependencies = [
- "bare-metal 1.0.0",
  "cortex-m",
  "critical-section",
  "portable-atomic",
@@ -511,7 +514,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-bus",
- "heapless",
+ "heapless 0.9.1",
  "loom",
  "portable-atomic",
  "rtic-common",
@@ -533,12 +536,11 @@ dependencies = [
 name = "rtic_lm3s6965"
 version = "0.1.0"
 dependencies = [
- "bare-metal 1.0.0",
  "cfg-if",
  "cortex-m",
  "cortex-m-semihosting",
  "futures",
- "heapless",
+ "heapless 0.8.0",
  "lm3s6965",
  "panic-semihosting",
  "rtic",

--- a/examples/lm3s6965/Cargo.toml
+++ b/examples/lm3s6965/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 heapless = "0.8"
 lm3s6965 = "0.2"
 cortex-m = "0.7.0"
-bare-metal = "1.0.0"
 cortex-m-semihosting = "0.5.0"
 rtic-time = { path = "../../rtic-time" }
 rtic-sync = { path = "../../rtic-sync" }

--- a/examples/lm3s6965/examples/init.rs
+++ b/examples/lm3s6965/examples/init.rs
@@ -31,7 +31,7 @@ mod app {
 
         // Access to the critical section token,
         // to indicate that this is a critical section
-        let _cs_token: bare_metal::CriticalSection = cx.cs;
+        let _cs_token: rtic::export::CriticalSection = cx.cs;
 
         hprintln!("init");
 

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -26,6 +26,7 @@ Example:
 
 ### Changed
 
+- Removed `bare_metal` in favour of `critical_section`.
 - Updated esp32c3 dependency to v0.30.0
 - Updated esp32c6 dependency to v0.21.0
 

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -30,7 +30,6 @@ esp32c3 = { version = "0.30.0", optional = true }
 esp32c6 = { version = "0.21.0", optional = true }
 riscv = { version = "0.15.0", optional = true }
 cortex-m = { version = "0.7.0", optional = true }
-bare-metal = "1.0.0"
 portable-atomic = { version = "1", default-features = false }
 rtic-macros = { path = "../rtic-macros", version = "=2.2.0" }
 rtic-core = "1"

--- a/rtic/src/export.rs
+++ b/rtic/src/export.rs
@@ -1,4 +1,4 @@
-pub use bare_metal::CriticalSection;
+pub use critical_section::CriticalSection;
 pub use portable_atomic as atomic;
 
 pub mod executor;


### PR DESCRIPTION
`bare_metal` was last time updated 3 years ago with a [deprecation].

<img width="1620" height="627" alt="image" src="https://github.com/user-attachments/assets/c7f701ec-73dd-4c3d-9887-6f1f3a0a2d9b" />

Yet, rtic still uses `bare_metal` and gives `ctx.cs` as `bare_metal::CriticalSection`. This is a problem because most libraries use `critical_section::CriticalSection`. And for some reason no one published `bare_metal 1.1.0`, thus on crates.io the critical section of the `bare_metal` is a different type from that of `critical_section`.

[deprecation]: https://github.com/rust-embedded/bare-metal/blob/master/src/lib.rs