### PR TITLE
Fix mutex send

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Fixed
+
+- Generated mutexes for shared resourses no longer implement `Send`. They are meant to be used inside a task locally.
+
 ### Added
 
 - Outer attributes applied to RTIC app module are now forwarded to the generated code.

--- a/rtic-macros/src/codegen/shared_resources.rs
+++ b/rtic-macros/src/codegen/shared_resources.rs
@@ -62,8 +62,13 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
                 #[allow(non_camel_case_types)]
                 #(#cfgs)*
                 pub struct #shared_name<'a> {
-                    __rtic_internal_p: ::core::marker::PhantomData<&'a ()>,
+                    __rtic_internal_p: ::core::marker::PhantomData<(&'a (), *const u8)>,
                 }
+
+                // Opt out from `Send`.
+                // `#shared_name` is trivially `Sync` because there are no `&self` methods.
+                // See https://doc.rust-lang.org/std/sync/struct.Exclusive.html .
+                unsafe impl<'a> Sync for #shared_name<'a> {}
 
                 #(#cfgs)*
                 impl<'a> #shared_name<'a> {

--- a/rtic-macros/src/codegen/shared_resources.rs
+++ b/rtic-macros/src/codegen/shared_resources.rs
@@ -68,6 +68,7 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
                 // Opt out from `Send`.
                 // `#shared_name` is trivially `Sync` because there are no `&self` methods.
                 // See https://doc.rust-lang.org/std/sync/struct.Exclusive.html .
+                #(#cfgs)*
                 unsafe impl<'a> Sync for #shared_name<'a> {}
 
                 #(#cfgs)*


### PR DESCRIPTION
Each mutex is generated uniquely for each task, it is unsound to send them between tasks. But they are `Send`. Before, it wasn't an issue, because you couldn't share non-`'static` data between them, but with #1043 you can make the mutex `'static`. Thus we need to use actual tools that Rust provides and out out from `Send`.

Currently, mutexes are simple ZSTs with `PhantomData<&'a ()>`, which is `Send`. We replace it with `PhantomData<(&'a (), *const u8)>`, and return `Sync` back via `unsafe` implementation. It is trivially sound, because mutexes have
no method methods that accept `&self`. See https://doc.rust-lang.org/std/sync/struct.Exclusive.html for details.
