### PR TITLE
CI: Cargo audit: Ignore RUSTSEC-2024-0436

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,3 +12,6 @@ jobs:
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2024-0436: Paste (which is mature/stable) only pulled in by examples/
+          # dependencies such as esp-hal, riscv, rp2040-hal, stm32f3xx-hal etc.
+          ignore: ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
CI Security audit is unhappy about `paste`

Pulled in by `riscv`:

```
paste 1.0.15
├── riscv 0.15.0
│   ├── rtic-monotonics 2.1.0
│   └── rtic 2.2.0
└── riscv 0.12.1
    └── riscv-slic 0.2.0
        └── rtic 2.2.0
```

and by `examples/`, see commit message.

[Author dtolnay considers `paste` 'finished'](https://github.com/rustsec/advisory-db/pull/2215#issuecomment-2709315704)

And as we only indirectly use `paste` we have no say if opportunistic replacement-forks will be adopted or not.

Fixes #1105
