### PR TITLE
Support external SYST clock source

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -10,6 +10,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ### Changed
 - Panic if STM32 prescaler value would overflow
 
+### Added
+
+- Cortex-M `systick` can be configured with its external clock source
+
 ## v2.1.0 - 2025-06-22
 
 ### Changed


### PR DESCRIPTION
Give users the option to configure SYST with an external clock source. By default, the clock source is the core, which keeps us backwards compatible.

`_start` has a new input, but since users don't call that function directly, it doesn't seem like a problem to break that public API.