### PR TITLE
fix the const assertion for the queue size

### DIFF
--- a/book/en/book.toml
+++ b/book/en/book.toml
@@ -6,7 +6,6 @@ authors = [
   "Jorge Aparicio <jorge@japaric.io>",
   "Per Lindgren <per.lindgren@ltu.se>",
 ]
-multilingual = false
 src = "src"
 title = "Real-Time Interrupt-driven Concurrency"
 
@@ -18,5 +17,5 @@ command = "mdbook-mermaid"
 
 [output.html]
 git-repository-url = "https://github.com/rtic-rs/rtic"
-git-repository-icon = "fa-github"
+git-repository-icon = "fab-github"
 additional-js = ["mermaid.min.js", "mermaid-init.js"]

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## [Unreleased]
 
+### Fixed
+
+- Const check for `channel::Channel` size smaller than 256 is now properly evaluated.
+
 ### Changed
 
 - Un-hide lifetimes of output type in `Signal::split` to resolve a new warning.

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -72,11 +72,17 @@ impl<T, const N: usize> Default for Channel<T, N> {
 }
 
 impl<T, const N: usize> Channel<T, N> {
-    const _CHECK: () = assert!(N < 256, "This queue support a maximum of 255 entries");
+    // Size check.
+    const fn size_check() {
+        // This limit comes from the the internal `Deque` structures used to track free and ready
+        // slots which have a type of [u8]
+        assert!(N < 256, "This queue support a maximum of 255 entries");
+    }
 
     /// Create a new channel.
     #[cfg(not(loom))]
     pub const fn new() -> Self {
+        Self::size_check();
         Self {
             freeq: UnsafeCell::new(Deque::new()),
             readyq: UnsafeCell::new(Deque::new()),
@@ -91,6 +97,7 @@ impl<T, const N: usize> Channel<T, N> {
     /// Create a new channel.
     #[cfg(loom)]
     pub fn new() -> Self {
+        Self::size_check();
         Self {
             freeq: UnsafeCell::new(Deque::new()),
             readyq: UnsafeCell::new(Deque::new()),

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -27,6 +27,8 @@ type WaitQueue = DoublyLinkedList<WaitQueueData>;
 ///
 /// This channel uses critical sections, however there are extremely small and all `memcpy`
 /// operations of `T` are done without critical sections.
+///
+/// Right now, the size of the queue `N` is limited to 255 elements.
 pub struct Channel<T, const N: usize> {
     // Here are all indexes that are not used in `slots` and ready to be allocated.
     freeq: UnsafeCell<Deque<u8, N>>,


### PR DESCRIPTION
The const check was not evaluated, see https://doc.rust-lang.org/reference/items/associated-items.html#r-items.associated.const.eval