### PR TITLE
Add watch sync primitive

### DIFF
--- a/ci/expected/lm3s6965/async-watch-uninitialized.run
+++ b/ci/expected/lm3s6965/async-watch-uninitialized.run
@@ -1,0 +1,1 @@
+Receiver got: None

--- a/ci/expected/lm3s6965/async-watch.run
+++ b/ci/expected/lm3s6965/async-watch.run
@@ -1,0 +1,3 @@
+Sender 1 writing: 1
+Receiver got: 1
+Receiver got: Some(1)

--- a/examples/lm3s6965/examples/async-watch-uninitialized.rs
+++ b/examples/lm3s6965/examples/async-watch-uninitialized.rs
@@ -1,0 +1,38 @@
+//! examples/async-watch-uninitialized.rs
+
+#![no_main]
+#![no_std]
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+
+use panic_semihosting as _;
+
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0])]
+mod app {
+    use cortex_m_semihosting::{debug, hprintln};
+    use rtic_sync::{watch::*, make_watch};
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        let (_s, r) = make_watch!(u32);
+
+        receiver::spawn(r).unwrap();
+
+        (Shared {}, Local {})
+    }
+
+    #[task]
+    async fn receiver(_c: receiver::Context, mut receiver: WatchReader<'static, u32>) {
+        let val = receiver.try_get();
+        hprintln!("Receiver got: {:?}", val);
+
+        debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator
+    }
+}

--- a/examples/lm3s6965/examples/async-watch.rs
+++ b/examples/lm3s6965/examples/async-watch.rs
@@ -1,0 +1,47 @@
+//! examples/async-watch.rs
+
+#![no_main]
+#![no_std]
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+
+use panic_semihosting as _;
+
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0])]
+mod app {
+    use cortex_m_semihosting::{debug, hprintln};
+    use rtic_sync::{watch::*, make_watch};
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        let (s, r) = make_watch!(u32);
+
+        receiver::spawn(r).unwrap();
+        sender::spawn(s.clone()).unwrap();
+
+        (Shared {}, Local {})
+    }
+
+    #[task]
+    async fn receiver(_c: receiver::Context, mut receiver: WatchReader<'static, u32>) {
+        let val = receiver.changed().await;
+        hprintln!("Receiver got: {}", val);
+        let val = receiver.try_get();
+        hprintln!("Receiver got: {:?}", val);
+
+        debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator
+    }
+
+    #[task]
+    async fn sender(_c: sender::Context, mut sender: WatchWriter<'static, u32>) {
+        hprintln!("Sender 1 writing: 1");
+        sender.write(1);
+    }
+}

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## [Unreleased]
 
+### Added
+
+- Add `Watch`. Similar to `Signal` but always returns latest value once initialized. Value never evicted.
+
 ### Fixed
 
 - Const check for `channel::Channel` size smaller than 256 is now properly evaluated.

--- a/rtic-sync/src/lib.rs
+++ b/rtic-sync/src/lib.rs
@@ -10,6 +10,7 @@ pub mod arbiter;
 pub mod channel;
 pub use portable_atomic;
 pub mod signal;
+pub mod watch;
 
 mod unsafecell;
 

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -6,15 +6,15 @@ use rtic_common::waker_registration::CriticalSectionWakerRegistration;
 /// Basically an Option but for indicating
 /// whether the store has been set or not
 #[derive(Clone, Copy)]
-enum Store<T> {
+pub(crate) enum Store<T> {
     Set(T),
     Unset,
 }
 
 /// A "latest only" value store with unlimited writers and async waiting.
 pub struct Signal<T: Copy> {
-    waker: CriticalSectionWakerRegistration,
-    store: UnsafeCell<Store<T>>,
+    pub(crate) waker: CriticalSectionWakerRegistration,
+    pub(crate) store: UnsafeCell<Store<T>>,
 }
 
 impl<T> core::fmt::Debug for Signal<T>
@@ -56,7 +56,7 @@ impl<T: Copy> Signal<T> {
 /// Facilitates the writing of values to a Signal.
 #[derive(Clone)]
 pub struct SignalWriter<'a, T: Copy> {
-    parent: &'a Signal<T>,
+    pub(crate) parent: &'a Signal<T>,
 }
 
 impl<T> core::fmt::Debug for SignalWriter<'_, T>
@@ -73,7 +73,7 @@ where
 
 impl<T: Copy> SignalWriter<'_, T> {
     /// Write a raw Store value to the Signal.
-    fn write_inner(&mut self, value: Store<T>) {
+    pub(crate) fn write_inner(&mut self, value: Store<T>) {
         critical_section::with(|_| {
             // SAFETY: in a cs: exclusive access
             unsafe { self.parent.store.get().replace(value) };

--- a/rtic-sync/src/watch.rs
+++ b/rtic-sync/src/watch.rs
@@ -1,0 +1,149 @@
+//! A "latest only" value store with unlimited writers and async waiting. Value is always available once initialized.
+
+use crate::signal::{Signal, SignalWriter, Store};
+
+/// A "latest only" value store with unlimited writers and async waiting. Value is always available once initialized.
+pub struct Watch<T: Copy>(Signal<T>);
+
+impl<T> core::fmt::Debug for Watch<T>
+where
+    T: core::marker::Copy,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_fmt(format_args!(
+            "Watch<{}>{{ .. }}",
+            core::any::type_name::<T>()
+        ))
+    }
+}
+
+impl<T: Copy> Default for Watch<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+unsafe impl<T: Copy> Send for Watch<T> {}
+unsafe impl<T: Copy> Sync for Watch<T> {}
+
+impl<T: Copy> Watch<T> {
+    /// Create a new watch.
+    pub const fn new() -> Self {
+        Self(Signal::new())
+    }
+
+    /// Split the watch into a writer and watch reader.
+    pub fn split(&self) -> (WatchWriter<'_, T>, WatchReader<'_, T>) {
+        (
+            WatchWriter(SignalWriter { parent: &self.0 }),
+            WatchReader { parent: &self.0 },
+        )
+    }
+}
+
+/// Creates a split watch with `'static` lifetime.
+#[macro_export]
+macro_rules! make_watch {
+    ( $T:ty ) => {{
+        static WATCH: $crate::watch::Watch<$T> = $crate::watch::Watch::new();
+
+        WATCH.split()
+    }};
+}
+
+/// Facilitates the writing of values to a Watch.
+#[derive(Clone)]
+pub struct WatchWriter<'a, T: Copy>(SignalWriter<'a, T>);
+
+impl<T> core::fmt::Debug for WatchWriter<'_, T>
+where
+    T: core::marker::Copy,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_fmt(format_args!(
+            "WatchWriter<{}>{{ .. }}",
+            core::any::type_name::<T>()
+        ))
+    }
+}
+
+impl<T: Copy> WatchWriter<'_, T> {
+    /// Write a value to the Watch.
+    pub fn write(&mut self, value: T) {
+        self.0.write(value);
+    }
+}
+
+/// Facilitates the async reading of values from the Watch.
+pub struct WatchReader<'a, T: Copy> {
+    parent: &'a Signal<T>,
+}
+
+impl<T> core::fmt::Debug for WatchReader<'_, T>
+where
+    T: core::marker::Copy,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_fmt(format_args!(
+            "WatchReader<{}>{{ .. }}",
+            core::any::type_name::<T>()
+        ))
+    }
+}
+
+impl<T: Copy> WatchReader<'_, T> {
+    /// Immediately get the latest value stored in the Signal.
+    fn get_inner(&mut self) -> Store<T> {
+        critical_section::with(|_| {
+            // SAFETY: in a cs: exclusive access
+            unsafe { self.parent.store.get().read() }
+        })
+    }
+
+    /// Returns the latest value, or None if uninitialized.
+    pub fn try_get(&mut self) -> Option<T> {
+        match self.get_inner() {
+            Store::Unset => None,
+            Store::Set(value) => Some(value),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(loom))]
+mod tests {
+    #[test]
+    fn empty() {
+        let (_writer, mut reader) = make_watch!(u32);
+
+        assert!(reader.try_get().is_none());
+    }
+
+    #[test]
+    fn ping_pong() {
+        let (mut writer, mut reader) = make_watch!(u32);
+
+        writer.write(0xde);
+        assert!(reader.try_get().is_some_and(|value| value == 0xde));
+    }
+
+    #[test]
+    fn latest() {
+        let (mut writer, mut reader) = make_watch!(u32);
+
+        writer.write(0xde);
+        writer.write(0xad);
+        writer.write(0xbe);
+        writer.write(0xef);
+        assert!(reader.try_get().is_some_and(|value| value == 0xef));
+    }
+
+    #[test]
+    fn no_consumption() {
+        let (mut writer, mut reader) = make_watch!(u32);
+
+        writer.write(0xaa);
+        assert!(reader.try_get().is_some_and(|value| value == 0xaa));
+        assert!(reader.try_get().is_some_and(|value| value == 0xaa));
+    }
+}


### PR DESCRIPTION
`watch` does not evict latest value as `signal` do. Once initialized the watch reader always return a value.