### PR TITLE
fix unhygienic panic use in macros and codegen

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- Generated `panic`s can no longer be shadowed. Previously, they were inconsistently shadowed.
 - Generated mutexes for shared resourses no longer implement `Send`. They are meant to be used inside a task locally.
 
 ### Added

--- a/rtic-macros/src/codegen/bindings/cortex.rs
+++ b/rtic-macros/src/codegen/bindings/cortex.rs
@@ -58,7 +58,7 @@ pub fn check_stack_overflow_before_init(
         if stack_start > ebss {
             // No flip-link usage, check the MSP for overflow.
             if rtic::export::msp::read() <= ebss {
-                panic!("Stack overflow after allocating executors");
+                ::core::panic!("Stack overflow after allocating executors");
             }
         }
     )]

--- a/rtic-macros/src/codegen/bindings/esp32c3.rs
+++ b/rtic-macros/src/codegen/bindings/esp32c3.rs
@@ -190,7 +190,7 @@ mod esp32c3 {
             if stack_start > ebss {
                 // No flip-link usage, check the SP for overflow.
                 if rtic::export::read_sp() <= ebss {
-                    panic!("Stack overflow after allocating executors");
+                    ::core::panic!("Stack overflow after allocating executors");
                 }
             }
         )]

--- a/rtic-macros/src/codegen/bindings/esp32c6.rs
+++ b/rtic-macros/src/codegen/bindings/esp32c6.rs
@@ -196,7 +196,7 @@ mod esp32c6 {
             if stack_start > ebss {
                 // No flip-link usage, check the SP for overflow.
                 if rtic::export::read_sp() <= ebss {
-                    panic!("Stack overflow after allocating executors");
+                    ::core::panic!("Stack overflow after allocating executors");
                 }
             }
         )]

--- a/rtic-macros/src/codegen/bindings/riscv_slic.rs
+++ b/rtic-macros/src/codegen/bindings/riscv_slic.rs
@@ -186,7 +186,7 @@ pub fn check_stack_overflow_before_init(
         if stack_start > ebss {
             // No flip-link usage, check the SP for overflow.
             if rtic::export::read_sp() <= ebss {
-                panic!("Stack overflow after allocating executors");
+                ::core::panic!("Stack overflow after allocating executors");
             }
         }
     )]

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -14,6 +14,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Cortex-M `systick` can be configured with its external clock source
 
+### Fixed
+
+- `assert`s in macro expansions can no longer be shadowed.
+
 ## v2.1.0 - 2025-06-22
 
 ### Changed

--- a/rtic-monotonics/src/imxrt.rs
+++ b/rtic-monotonics/src/imxrt.rs
@@ -247,13 +247,13 @@ macro_rules! make_timer {
                 if rollover != 0 {
                     let prev = $period.fetch_add(1, Ordering::Relaxed);
                     ral::write_reg!(ral::gpt, gpt, SR, ROV: 1);
-                    assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
+                    ::core::assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
                 }
 
                 if half_rollover != 0 {
                     let prev = $period.fetch_add(1, Ordering::Relaxed);
                     ral::write_reg!(ral::gpt, gpt, SR, OF1: 1);
-                    assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
+                    ::core::assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
                 }
             }
 

--- a/rtic-monotonics/src/nrf/rtc.rs
+++ b/rtic-monotonics/src/nrf/rtc.rs
@@ -256,12 +256,12 @@ macro_rules! make_rtc {
                 if rtc.events_ovrflw.read().bits() == 1 {
                     rtc.events_ovrflw.write(|w| unsafe { w.bits(0) });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
+                    ::core::assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
                 }
                 if rtc.events_compare[1].read().bits() == 1 {
                     rtc.events_compare[1].write(|w| unsafe { w.bits(0) });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
+                    ::core::assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
                 }
             }
 

--- a/rtic-monotonics/src/nrf/timer.rs
+++ b/rtic-monotonics/src/nrf/timer.rs
@@ -120,7 +120,7 @@ macro_rules! __internal_create_nrf_timer_struct {
                     125_000 => 7,
                     62_500 => 8,
                     31_250 => 9,
-                    _ => panic!("Timer cannot run at desired tick rate!"),
+                    _ => ::core::panic!("Timer cannot run at desired tick rate!"),
                 };
 
                 $crate::nrf::timer::$mono_backend::_start(timer, PRESCALER);
@@ -298,14 +298,14 @@ macro_rules! make_timer {
                 if timer.events_compare[1].read().bits() & 1 != 0 {
                     timer.events_compare[1].write(|w| w);
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
+                    ::core::assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
                 }
 
                 // If there is a compare match on channel 2, it is a half-period overflow
                 if timer.events_compare[2].read().bits() & 1 != 0 {
                     timer.events_compare[2].write(|w| w);
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
+                    ::core::assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
                 }
             }
 

--- a/rtic-monotonics/src/stm32.rs
+++ b/rtic-monotonics/src/stm32.rs
@@ -237,9 +237,9 @@ macro_rules! make_timer {
 
                 $timer.cr1().modify(|r| r.set_cen(false));
 
-                assert!((tim_clock_hz % timer_hz) == 0, "Unable to find suitable timer prescaler value!");
+                ::core::assert!((tim_clock_hz % timer_hz) == 0, "Unable to find suitable timer prescaler value!");
                 let Ok(psc) = u16::try_from(tim_clock_hz / timer_hz - 1) else {
-                    panic!("Clock prescaler overflowed!");
+                    ::core::panic!("Clock prescaler overflowed!");
                 };
                 $timer.psc().write(|r| *r = psc);
 
@@ -335,7 +335,7 @@ macro_rules! make_timer {
                         r.set_uif(false);
                     });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
+                    ::core::assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
                 }
                 // Half period
                 if $timer.sr().read().ccif(0) {
@@ -344,7 +344,7 @@ macro_rules! make_timer {
                         r.set_ccif(0, false);
                     });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
+                    ::core::assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
                 }
             }
 
@@ -381,9 +381,9 @@ macro_rules! make_timer2 {
 
                 $timer.cr1().modify(|r| r.set_cen(false));
 
-                assert!((tim_clock_hz % timer_hz) == 0, "Unable to find suitable timer prescaler value!");
+                ::core::assert!((tim_clock_hz % timer_hz) == 0, "Unable to find suitable timer prescaler value!");
                 let Ok(psc) = u16::try_from(tim_clock_hz / timer_hz - 1) else {
-                    panic!("Clock prescaler overflowed!");
+                    ::core::panic!("Clock prescaler overflowed!");
                 };
                 $timer.psc().write(|r| *r = psc);
 
@@ -479,7 +479,7 @@ macro_rules! make_timer2 {
                         r.set_uif(false);
                     });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
+                    ::core::assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
                 }
                 // Half period
                 if $timer.sr().read().ccif(0) {
@@ -488,7 +488,7 @@ macro_rules! make_timer2 {
                         r.set_ccif(0, false);
                     });
                     let prev = $overflow.fetch_add(1, Ordering::Relaxed);
-                    assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
+                    ::core::assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
                 }
             }
 

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -13,6 +13,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Fixed
 
+- The `panic` in `make_channel` can no longer be shadowed.
 - Const check for `channel::Channel` size smaller than 256 is now properly evaluated.
 
 ### Changed

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -196,7 +196,7 @@ macro_rules! make_channel {
 
         $crate::channel::critical_section::with(|_| {
             if CHECK.load(::core::sync::atomic::Ordering::Relaxed) != 0 {
-                panic!("call to the same `make_channel` instance twice");
+                ::core::panic!("call to the same `make_channel` instance twice");
             }
 
             CHECK.store(1, ::core::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
In some places in codegen, `::core::panic` was used, but in others places plain `panic` was used. This meant that a macro caller could shadow the definition for some panics (for example with `defmt::panic`), but not others. Fix this inconsistency by using `::core::panic` everywhere.

This affects not only the `rtic::app` proc macro, but also `macro_rules` [1]. I searched for and changed the following in both:

- assert_eq
- assert_ne
- assert
- debug_assert_eq
- debug_assert_ne
- debug_assert
- todo
- unimplemented
- unreachable
- panic

[1]: https://doc.rust-lang.org/reference/macros-by-example.html#hygiene