### PR TITLE
Update rp235x-pac to 0.2.0

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -8,6 +8,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 ## Unreleased
 
 ### Changed
+
+- Updated rp235x-pac dependency to v0.2.0
 - Panic if STM32 prescaler value would overflow
 
 ### Added

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -48,7 +48,7 @@ critical-section = { version = "1", optional = true }
 rp2040-pac = { version = "0.6", optional = true }
 
 # RP235x
-rp235x-pac = { version = "0.1.0", optional = true }
+rp235x-pac = { version = "0.2.0", optional = true }
 
 # nRF52
 nrf52805-pac = { version = "0.12.2", optional = true }


### PR DESCRIPTION
[rp235x-hal 0.4.0](https://github.com/rp-rs/rp-hal/releases/tag/rp235x-hal-0.4.0) updates rp235x-pac to 0.2.0, creating a dependency conflict.
Was tested on actual hardware and seem to work without any further changes.