### PR TITLE
bump lm3s6965 crate version on release/v1 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Bump lm3s6965 to 0.2.0
+
 ## [v1.1.4] - 2023-02-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bare-metal = "1.0.0"
 version_check = "0.9"
 
 [dev-dependencies]
-lm3s6965 = "0.1.3"
+lm3s6965 = "0.2.0"
 cortex-m-semihosting = "0.5.0"
 systick-monotonic = "1.0.0"
 


### PR DESCRIPTION
Require version 0.2.0 of the `lm3s6965` crate, when building examples.

The older version does not compile anymore, it fails due to missing `Copy` trait for `lm3s6965::Interrupt` type.