### PR TITLE
Add `have_basepri` to the list of expected build-time configs (release/v1).

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,9 @@ fn main() {
         println!("cargo:rustc-cfg=rustc_is_nightly");
     }
 
+    // Add `have_basepri` to the list of expected configs.
+    println!("cargo::rustc-check-cfg=cfg(have_basepri)");
+
     // These targets all have know support for the BASEPRI register.
     if target.starts_with("thumbv7m")
         | target.starts_with("thumbv7em")

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,8 @@ fn main() {
 
     // Add `have_basepri` to the list of expected configs.
     println!("cargo::rustc-check-cfg=cfg(have_basepri)");
+    println!("cargo::rustc-check-cfg=cfg(never)");
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"killmono\", \"feature_x\"))");
 
     // These targets all have know support for the BASEPRI register.
     if target.starts_with("thumbv7m")

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -127,21 +127,17 @@ pub fn codegen(
             // If any resource to the exception uses non-lock-free or non-local resources this is
             // not allwed on thumbv6.
             uses_exceptions_with_resources = uses_exceptions_with_resources
-                || task
-                    .args
-                    .shared_resources
-                    .iter()
-                    .any(|(ident, access)| {
-                        if access.is_exclusive() {
-                            if let Some(r) = app.shared_resources.get(ident) {
-                                !r.properties.lock_free
-                            } else {
-                                false
-                            }
+                || task.args.shared_resources.iter().any(|(ident, access)| {
+                    if access.is_exclusive() {
+                        if let Some(r) = app.shared_resources.get(ident) {
+                            !r.properties.lock_free
                         } else {
                             false
                         }
-                    });
+                    } else {
+                        false
+                    }
+                });
 
             None
         }

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -131,7 +131,7 @@ pub fn codegen(
                     .args
                     .shared_resources
                     .iter()
-                    .map(|(ident, access)| {
+                    .any(|(ident, access)| {
                         if access.is_exclusive() {
                             if let Some(r) = app.shared_resources.get(ident) {
                                 !r.properties.lock_free
@@ -141,8 +141,7 @@ pub fn codegen(
                         } else {
                             false
                         }
-                    })
-                    .any(|v| v);
+                    });
 
             None
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -80,7 +80,7 @@ pub fn app(args: TokenStream, input: TokenStream) -> TokenStream {
         //
         // If no "target" directory is found, <project_dir>/<out_dir_root> is used
         for path in out_dir.ancestors() {
-            if let Some(dir) = path.components().last() {
+            if let Some(dir) = path.components().next_back() {
                 if dir
                     .as_os_str()
                     .to_str()

--- a/src/export.rs
+++ b/src/export.rs
@@ -87,6 +87,12 @@ pub struct Barrier {
     inner: AtomicBool,
 }
 
+impl Default for Barrier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Barrier {
     pub const fn new() -> Self {
         Barrier {
@@ -264,7 +270,9 @@ pub unsafe fn lock<T, R, const M: usize>(
 ///     - we execute the closure in a global critical section (interrupt free)
 ///     - CS entry cost, single write to core register
 ///     - CS exit cost, single write to core register
+///
 ///   else
+///
 ///     - The `mask` value is folded to a constant at compile time
 ///     - CS entry, single write of the 32 bit `mask` to the `icer` register
 ///     - CS exit, single write of the 32 bit `mask` to the `iser` register

--- a/src/tq.rs
+++ b/src/tq.rs
@@ -34,7 +34,7 @@ where
         // Check if the top contains a non-empty element and if that element is
         // greater than nr
         let if_heap_max_greater_than_nr =
-            self.0.peek().map_or(true, |head| nr.instant < head.instant);
+            self.0.peek().is_none_or(|head| nr.instant < head.instant);
 
         if if_heap_max_greater_than_nr {
             if Mono::DISABLE_INTERRUPT_ON_EMPTY_QUEUE && self.0.is_empty() {


### PR DESCRIPTION
This fixes this warning while building:

    warning: unexpected `cfg` condition name: `have_basepri`