### PR TITLE
Fix failing compile error tests (release/v1)

### DIFF
--- a/ui/task-priority-too-high.stderr
+++ b/ui/task-priority-too-high.stderr
@@ -1,7 +1,5 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation panicked: Maximum priority used by interrupt vector 'I2C0' is more than supported by hardware
  --> ui/task-priority-too-high.rs:3:1
   |
 3 | #[rtic::app(device = lm3s6965)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Maximum priority used by interrupt vector 'I2C0' is more than supported by hardware', $DIR/ui/task-priority-too-high.rs:3:1
-  |
-  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `::core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `app::rtic_ext::main::_` failed here

--- a/ui/unknown-interrupt.rs
+++ b/ui/unknown-interrupt.rs
@@ -9,7 +9,7 @@ mod app {
     struct Local {}
 
     #[init]
-    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
         (Shared {}, Local {}, init::Monotonics())
     }
 }

--- a/ui/unknown-interrupt.stderr
+++ b/ui/unknown-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no variant or associated item named `UnknownInterrupt` found for enum `Interrupt` in the current scope
- --> $DIR/unknown-interrupt.rs:3:47
+ --> ui/unknown-interrupt.rs:3:47
   |
 3 | #[rtic::app(device = lm3s6965, dispatchers = [UnknownInterrupt])]
   |                                               ^^^^^^^^^^^^^^^^ variant or associated item not found in `Interrupt`


### PR DESCRIPTION
Fixes test that fail when running:

`cargo test --test tests`

Basically update expected error messages, to new wording.