### PR TITLE
examples: fix typo in sleeponexit

### DIFF
--- a/book/en/src/by-example/app_idle.md
+++ b/book/en/src/by-example/app_idle.md
@@ -34,7 +34,7 @@ A common useful optimization is to enable the [SLEEPONEXIT] and allow the MCU to
 The following example shows how to enable sleep by setting the
 [`SLEEPONEXIT`][SLEEPONEXIT] and providing a custom `idle` task replacing the default [`nop()`][NOP] with [`wfi()`][WFI].
 
-[SLEEPONEXIT]: https://developer.arm.com/docs/100737/0100/power-management/sleep-mode/sleep-on-exit-bit
+[SLEEPONEXIT]: https://developer.arm.com/documentation/100737/0100/Power-management/Sleep-mode/Sleep-on-exit-bit
 [WFI]: https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Instruction-Set/Miscellaneous-instructions/WFI
 [NOP]: https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Instruction-Set/Miscellaneous-instructions/NOP
 

--- a/examples/lm3s6965/examples/idle-wfi.rs
+++ b/examples/lm3s6965/examples/idle-wfi.rs
@@ -24,7 +24,7 @@ mod app {
 
         // Set the ARM SLEEPONEXIT bit to go to sleep after handling interrupts
         // See https://developer.arm.com/docs/100737/0100/power-management/sleep-mode/sleep-on-exit-bit
-        cx.core.SCB.set_sleepdeep();
+        cx.core.SCB.set_sleeponexit();
 
         (Shared {}, Local {})
     }

--- a/examples/lm3s6965/examples/idle-wfi.rs
+++ b/examples/lm3s6965/examples/idle-wfi.rs
@@ -23,7 +23,7 @@ mod app {
         hprintln!("init");
 
         // Set the ARM SLEEPONEXIT bit to go to sleep after handling interrupts
-        // See https://developer.arm.com/docs/100737/0100/power-management/sleep-mode/sleep-on-exit-bit
+        // See https://developer.arm.com/documentation/100737/0100/Power-management/Sleep-mode/Sleep-on-exit-bit
         cx.core.SCB.set_sleeponexit();
 
         (Shared {}, Local {})


### PR DESCRIPTION
The documentation said `SLEEPONEXIT` (which seems correct), but the code contained `set_sleepdeep`.

Also, the doc links were broken.