### PR TITLE
Update `fugit` to `0.4.0`

### DIFF
--- a/examples/nrf52840_blinky/Cargo.toml
+++ b/examples/nrf52840_blinky/Cargo.toml
@@ -17,7 +17,7 @@ defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 cortex-m-semihosting = "0.5.0"
 nrf52840-hal = "0.16.0"
-fugit = { version = "0.3.7", features = ["defmt"] }
+fugit = { version = "0.4.0", features = ["defmt"] }
 
 [dependencies.rtic]
 path = "../../rtic"

--- a/examples/rp2040_local_i2c_init/Cargo.toml
+++ b/examples/rp2040_local_i2c_init/Cargo.toml
@@ -21,7 +21,7 @@ features = ["rp2040"]
 [dependencies]
 cortex-m = "0.7"
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
-fugit = "0.3"
+fugit = "0.4.0"
 rp-pico = "0.9.0"
 panic-probe = "0.3"
 portable-atomic = { version = "1", features = ["critical-section"] }

--- a/examples/stm32g030f6_periodic_prints/Cargo.toml
+++ b/examples/stm32g030f6_periodic_prints/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 defmt = "0.3.8"
 defmt-rtt = "0.4.1"
-fugit = "0.3.7"
+fugit = "0.4.0"
 panic-probe = { version = "0.3.2", features = ["print-defmt"] }
 portable-atomic = { version = "1", features = ["unsafe-assume-single-core"] }
 

--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Updated fugit dependency to v0.4.0
 - STM32's monotonics now derive the timer counter size from the pac register definition
 - Updated rp235x-pac dependency to v0.2.0
 - Panic if STM32 prescaler value would overflow

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -39,7 +39,7 @@ rustdoc-flags = ["--cfg", "docsrs"]
 
 [dependencies]
 rtic-time = { version = "2.0.0", path = "../rtic-time" }
-fugit = { version = "0.3.6" }
+fugit = { version = "0.4.0" }
 portable-atomic = { version = "1" }
 cfg-if = "1.0.0"
 cortex-m = { version = "0.7.6", optional = true }

--- a/rtic-time/CHANGELOG.md
+++ b/rtic-time/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## Unreleased
 
+### Changed
+
+- Updated fugit dependency to v0.4.0
+
 ## v2.0.1 - 2025-06-22
 
 ### Changed

--- a/rtic-time/Cargo.toml
+++ b/rtic-time/Cargo.toml
@@ -4,11 +4,11 @@ version = "2.0.1"
 
 edition = "2021"
 authors = [
-  "The Real-Time Interrupt-driven Concurrency developers",
-  "Emil Fresk <emil.fresk@gmail.com>",
-  "Henrik Tjäder <henrik@tjaders.com>",
-  "Jorge Aparicio <jorge@japaric.io>",
-  "Per Lindgren <per.lindgren@ltu.se>",
+    "The Real-Time Interrupt-driven Concurrency developers",
+    "Emil Fresk <emil.fresk@gmail.com>",
+    "Henrik Tjäder <henrik@tjaders.com>",
+    "Jorge Aparicio <jorge@japaric.io>",
+    "Per Lindgren <per.lindgren@ltu.se>",
 ]
 categories = ["concurrency", "embedded", "no-std", "asynchronous"]
 description = "Basic definitions and utilities that can be used to keep track of time"
@@ -23,7 +23,7 @@ futures-util = { version = "0.3.25", default-features = false }
 rtic-common = { version = "1.0.0", path = "../rtic-common" }
 embedded-hal = { version = "1.0.0" }
 embedded-hal-async = { version = "1.0.0" }
-fugit = "0.3.7"
+fugit = "0.4.0"
 
 [dev-dependencies]
 parking_lot = "0.12"

--- a/rtic-time/src/monotonic/embedded_hal_macros.rs
+++ b/rtic-time/src/monotonic/embedded_hal_macros.rs
@@ -8,7 +8,7 @@ macro_rules! impl_embedded_hal_delay_fugit {
             fn delay_ns(&mut self, ns: u32) {
                 let now = <Self as $crate::Monotonic>::now();
                 let mut done =
-                    now + <Self as $crate::Monotonic>::Duration::nanos_at_least(ns.into());
+                    now + <Self as $crate::Monotonic>::Duration::from_nanos_at_least(ns.into());
                 if now != done {
                     // Compensate for sub-tick uncertainty
                     done += <Self as $crate::Monotonic>::Duration::from_ticks(1);
@@ -20,7 +20,7 @@ macro_rules! impl_embedded_hal_delay_fugit {
             fn delay_us(&mut self, us: u32) {
                 let now = <Self as $crate::Monotonic>::now();
                 let mut done =
-                    now + <Self as $crate::Monotonic>::Duration::micros_at_least(us.into());
+                    now + <Self as $crate::Monotonic>::Duration::from_micros_at_least(us.into());
                 if now != done {
                     // Compensate for sub-tick uncertainty
                     done += <Self as $crate::Monotonic>::Duration::from_ticks(1);
@@ -32,7 +32,7 @@ macro_rules! impl_embedded_hal_delay_fugit {
             fn delay_ms(&mut self, ms: u32) {
                 let now = <Self as $crate::Monotonic>::now();
                 let mut done =
-                    now + <Self as $crate::Monotonic>::Duration::millis_at_least(ms.into());
+                    now + <Self as $crate::Monotonic>::Duration::from_millis_at_least(ms.into());
                 if now != done {
                     // Compensate for sub-tick uncertainty
                     done += <Self as $crate::Monotonic>::Duration::from_ticks(1);
@@ -52,7 +52,7 @@ macro_rules! impl_embedded_hal_async_delay_fugit {
             #[inline]
             async fn delay_ns(&mut self, ns: u32) {
                 <Self as $crate::Monotonic>::delay(
-                    <Self as $crate::Monotonic>::Duration::nanos_at_least(ns.into()),
+                    <Self as $crate::Monotonic>::Duration::from_nanos_at_least(ns.into()),
                 )
                 .await;
             }
@@ -60,7 +60,7 @@ macro_rules! impl_embedded_hal_async_delay_fugit {
             #[inline]
             async fn delay_us(&mut self, us: u32) {
                 <Self as $crate::Monotonic>::delay(
-                    <Self as $crate::Monotonic>::Duration::micros_at_least(us.into()),
+                    <Self as $crate::Monotonic>::Duration::from_micros_at_least(us.into()),
                 )
                 .await;
             }
@@ -68,7 +68,7 @@ macro_rules! impl_embedded_hal_async_delay_fugit {
             #[inline]
             async fn delay_ms(&mut self, ms: u32) {
                 <Self as $crate::Monotonic>::delay(
-                    <Self as $crate::Monotonic>::Duration::millis_at_least(ms.into()),
+                    <Self as $crate::Monotonic>::Duration::from_millis_at_least(ms.into()),
                 )
                 .await;
             }

--- a/rtic-time/src/monotonic/timer_queue_based_monotonic.rs
+++ b/rtic-time/src/monotonic/timer_queue_based_monotonic.rs
@@ -74,40 +74,40 @@ pub trait TimerQueueBasedDuration: Copy {
     fn ticks(self) -> Self::Ticks;
 }
 
-impl<const NOM: u32, const DENOM: u32> TimerQueueBasedInstant for fugit::Instant<u64, NOM, DENOM> {
+impl<const NOM: u64, const DENOM: u64> TimerQueueBasedInstant for fugit::Instant<u64, NOM, DENOM> {
     type Ticks = u64;
     fn from_ticks(ticks: Self::Ticks) -> Self {
         Self::from_ticks(ticks)
     }
     fn ticks(self) -> Self::Ticks {
-        Self::ticks(&self)
+        Self::as_ticks(&self)
     }
 }
 
-impl<const NOM: u32, const DENOM: u32> TimerQueueBasedInstant for fugit::Instant<u32, NOM, DENOM> {
+impl<const NOM: u64, const DENOM: u64> TimerQueueBasedInstant for fugit::Instant<u32, NOM, DENOM> {
     type Ticks = u32;
     fn from_ticks(ticks: Self::Ticks) -> Self {
         Self::from_ticks(ticks)
     }
     fn ticks(self) -> Self::Ticks {
-        Self::ticks(&self)
+        Self::as_ticks(&self)
     }
 }
 
-impl<const NOM: u32, const DENOM: u32> TimerQueueBasedDuration
+impl<const NOM: u64, const DENOM: u64> TimerQueueBasedDuration
     for fugit::Duration<u64, NOM, DENOM>
 {
     type Ticks = u64;
     fn ticks(self) -> Self::Ticks {
-        Self::ticks(&self)
+        Self::as_ticks(&self)
     }
 }
 
-impl<const NOM: u32, const DENOM: u32> TimerQueueBasedDuration
+impl<const NOM: u64, const DENOM: u64> TimerQueueBasedDuration
     for fugit::Duration<u32, NOM, DENOM>
 {
     type Ticks = u32;
     fn ticks(self) -> Self::Ticks {
-        Self::ticks(&self)
+        Self::as_ticks(&self)
     }
 }

--- a/rtic-time/tests/delay_precision_subtick.rs
+++ b/rtic-time/tests/delay_precision_subtick.rs
@@ -24,7 +24,7 @@ use rtic_time::{
     Monotonic,
 };
 
-const SUBTICKS_PER_TICK: u32 = 10;
+const SUBTICKS_PER_TICK: u64 = 10;
 struct SubtickTestTimer;
 struct SubtickTestTimerBackend;
 static TIMER_QUEUE: TimerQueue<SubtickTestTimerBackend> = TimerQueue::new();
@@ -44,8 +44,8 @@ impl SubtickTestTimerBackend {
 
     pub fn tick() -> u64 {
         let now = NOW_SUBTICKS.fetch_add(1, Ordering::Relaxed) + 1;
-        let ticks = now / u64::from(SUBTICKS_PER_TICK);
-        let subticks = now % u64::from(SUBTICKS_PER_TICK);
+        let ticks = now / SUBTICKS_PER_TICK;
+        let subticks = now % SUBTICKS_PER_TICK;
 
         let compare = COMPARE_TICKS.lock();
 
@@ -63,7 +63,7 @@ impl SubtickTestTimerBackend {
     }
 
     pub fn forward_to_subtick(subtick: u64) {
-        assert!(subtick < u64::from(SUBTICKS_PER_TICK));
+        assert!(subtick < SUBTICKS_PER_TICK);
         while Self::tick() != subtick {}
     }
 
@@ -76,7 +76,7 @@ impl TimerQueueBackend for SubtickTestTimerBackend {
     type Ticks = u64;
 
     fn now() -> Self::Ticks {
-        NOW_SUBTICKS.load(Ordering::Relaxed) / u64::from(SUBTICKS_PER_TICK)
+        NOW_SUBTICKS.load(Ordering::Relaxed) / SUBTICKS_PER_TICK
     }
 
     fn set_compare(instant: Self::Ticks) {

--- a/rtic-time/tests/timer_queue.rs
+++ b/rtic-time/tests/timer_queue.rs
@@ -72,7 +72,7 @@ impl TestMonoBackend {
     }
 
     pub fn compare() -> Option<u64> {
-        COMPARE.lock().clone()
+        *COMPARE.lock()
     }
 }
 


### PR DESCRIPTION
**IMPORTANT**: This is a breaking change!

- `Mono::now()` API has changed
- External crates that depend on monotonics are now incompatible until updated to the new `fugit` version as well

Strong recommendation to major version bump `rtic-monotonics` and `rtic-time`!