### PR TITLE
Release rtic sync v1.5.0

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -5,7 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
-## [Unreleased]
+## Unreleased
+
+## v1.5.0 - 2026-05-30
 
 ### Added
 
@@ -13,6 +15,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Fixed
 
+- Fix a correctness bug that allowed a `Signal` to be split more than once.
 - The `panic` in `make_channel` can no longer be shadowed.
 - Const check for `channel::Channel` size smaller than 256 is now properly evaluated.
 

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -49,7 +49,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - Improve handling of free slots for `send` by explicitly writing the free slot to the awoken future.
 - Fix all known instances of #780
 
-## v1.3.1 - 2025-03-12
+## v1.3.1 - 2025-03-12 - yanked
 
 ### Fixed
 
@@ -57,7 +57,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 [#780]: https://github.com/rtic-rs/rtic/issues/780
 
-## v1.3.0 - 2024-05-01
+## v1.3.0 - 2024-05-01 - yanked
 
 ### Changed
 
@@ -69,7 +69,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - `defmt v0.3` derives added and forwarded to `embedded-hal(-x)` crates.
 - signal structure
 
-## v1.2.0 - 2024-01-10
+## v1.2.0 - 2024-01-10 - yanked
 
 ### Changed
 
@@ -79,30 +79,30 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 - `make_channel` now accepts `Type` expressions instead of only `TypePath` expressions.
 
-## v1.1.1 - 2023-12-04
+## v1.1.1 - 2023-12-04 - yanked
 
 ### Fixed
 
 - Fix features for `docs.rs`
 
-## v1.1.0 - 2023-12-04
+## v1.1.0 - 2023-12-04 - yanked
 
 ### Added
 
 - `arbiter::spi::ArbiterDevice` for sharing SPI buses using `embedded-hal-async` traits.
 - `arbiter::i2c::ArbiterDevice` for sharing I2C buses using `embedded-hal-async` traits.
 
-## v1.0.3
+## v1.0.3 - yanked
 
 - `portable-atomic` used as a drop in replacement for `core::sync::atomic` in code and macros. `portable-atomic` imported with `default-features = false`, as we do not require CAS.
 
-## v1.0.2 - 2023-08-29
+## v1.0.2 - 2023-08-29 - yanked
 
 ### Fixed
 
 - `make_channel` no longer requires the user crate to have `critical_section` in scope
 
-## v1.0.1 - 2023-06-14
+## v1.0.1 - 2023-06-14 - yanked
 
 ### Fixed
 

--- a/rtic-sync/Cargo.toml
+++ b/rtic-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtic-sync"
-version = "1.4.0"
+version = "1.5.0"
 
 edition = "2021"
 authors = [


### PR DESCRIPTION
Some handy fixes, and the very nice `Watch` channel have been laying around for a while. It felt reasonable to do a release.

Also added "yanked" notices to all versions of `rtic-sync` that are actually yanked. I don't believe 1.4.0 needs yanking: it has some correctness (i.e. "can we use the crate correctly") bugs, but no soundness issues.
