### PR TITLE
Assert task local external resources are Send

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -11,6 +11,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 - Generated `panic`s can no longer be shadowed. Previously, they were inconsistently shadowed.
 - Generated mutexes for shared resourses no longer implement `Send`. They are meant to be used inside a task locally.
+- Consider task-local external resources when identifying which resources must be `Send`.
 
 ### Added
 

--- a/rtic-macros/src/syntax/analyze.rs
+++ b/rtic-macros/src/syntax/analyze.rs
@@ -242,9 +242,18 @@ pub(crate) fn app(app: &App) -> Result<Analysis, syn::Error> {
     // Create the list of used local resource Idents
     let mut used_local_resource = IndexSet::new();
 
-    for (_, _, locals, _) in task_resources_list {
-        for (local, _) in locals {
+    for (_, _, locals, priority) in task_resources_list {
+        for (local, kind) in locals {
             used_local_resource.insert(local.clone());
+
+            // Declared task-local resources have implicitly
+            // owned ownership. If we included them in this
+            // collection, we would need to exclude them when
+            // performing the "is it Send?" analysis later in
+            // this routine.
+            if matches!(kind, TaskLocal::External) {
+                ownerships.insert(local.clone(), Ownership::Owned { priority });
+            }
         }
     }
 

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -20,6 +20,10 @@ Example:
 
 ## [Unreleased]
 
+### Fixed
+
+- **Soundness fix:**: Assert that `Local` resources initialized by `init` are `Send`.
+
 ### Added
 
 - Outer attributes applied to RTIC app module are now forwarded to the generated code.

--- a/rtic/ui/locals-not-send.rs
+++ b/rtic/ui/locals-not-send.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+#[rtic::app(device = lm3s6965)]
+mod app {
+    use core::cell::RefCell;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        x: &'static RefCell<u32>,
+        y: &'static RefCell<u32>,
+    }
+
+    #[init(local = [xy: RefCell<u32> = RefCell::new(0)])]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        (
+            Shared {},
+            Local {
+                x: cx.local.xy,
+                y: cx.local.xy,
+            },
+        )
+    }
+
+    #[task(binds = SSI0, priority = 1, local = [x])]
+    fn p1(cx: p1::Context) {
+        *cx.local.x.borrow_mut() += 1;
+    }
+
+    #[task(binds = QEI0, priority = 2, local = [y])]
+    fn p2(cx: p2::Context) {
+        *cx.local.y.borrow_mut() += 1;
+    }
+}

--- a/rtic/ui/locals-not-send.stderr
+++ b/rtic/ui/locals-not-send.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `&'static RefCell<u32>` cannot be sent between threads safely
+  --> ui/locals-not-send.rs:12:12
+   |
+12 |         x: &'static RefCell<u32>,
+   |            ^^^^^^^^^^^^^^^^^^^^^ `&'static RefCell<u32>` cannot be sent between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `RefCell<u32>`
+   = note: required for `&'static RefCell<u32>` to implement `Send`
+note: required by a bound in `rtic::export::assert_send`
+  --> src/export.rs
+   |
+   | pub fn assert_send<T: Send>() {}
+   |                       ^^^^ required by this bound in `assert_send`
+help: consider removing the leading `&`-reference
+   |
+12 -         x: &'static RefCell<u32>,
+12 +         x: RefCell<u32>,
+   |


### PR DESCRIPTION
The RTIC docs claim

https://github.com/rtic-rs/rtic/blob/28652962d3c46bab79d5fa466815fd68d5cf7cb3/book/en/src/by-example/resources.md?plain=1#L22

However, RTIC doesn't assert this. We see this by undo-ing the changes in analyze.rs and observing a successful build of the new test.

The analysis tries to assert that its resources are Send using the loop shown below. Until now, we never filled the ownerships collection with local resources, so we never took the branch to update send_types.

https://github.com/rtic-rs/rtic/blob/28652962d3c46bab79d5fa466815fd68d5cf7cb3/rtic-macros/src/syntax/analyze.rs#L268-L281

With this commit, RTIC rejects programs it previously accepted. I think users might appreciate the extra check, even if it comes unexpectedly from a non-breaking update.