### PR TITLE
Use `syn` crate version 2 for release/v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   # Run cargo fmt --check, includes macros/
   style:
     name: style
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
   # Compilation check
   check:
     name: check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:
@@ -64,7 +64,7 @@ jobs:
   # Clippy
   clippy:
     name: Cargo clippy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
   # Verify all examples, checks
   checkexamples:
     name: checkexamples
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:
@@ -118,7 +118,7 @@ jobs:
   # Verify the example output with run-pass tests
   testexamples:
     name: testexamples
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:
@@ -162,7 +162,7 @@ jobs:
   # Check the correctness of macros/ crate
   checkmacros:
     name: checkmacros
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:
@@ -193,7 +193,7 @@ jobs:
   # Run the  macros test-suite
   testmacros:
     name: testmacros
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -210,7 +210,7 @@ jobs:
   # Run test suite
   tests:
     name: tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -227,7 +227,7 @@ jobs:
   # Build documentation, check links
   docs:
     name: docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -272,7 +272,7 @@ jobs:
   # Build the books
   mdbook:
     name: mdbook
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -319,7 +319,7 @@ jobs:
   # This needs to run before book is built
   mergetostablebranch:
     name: If CI passes, merge master branch into release/vX
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - style
       - check
@@ -360,7 +360,7 @@ jobs:
   # If all tests pass, then deploy stage is run
   deploy:
     name: deploy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       mergetostablebranch
 
@@ -513,7 +513,7 @@ jobs:
       - tests
       - docs
       - mdbook
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Mark the job as a success
         run: exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Update rtic-syntax to pre-release supporting syn v2
 - Bump lm3s6965 to 0.2.0
 
 ## [v1.1.4] - 2023-02-26

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 proc-macro2 = "1"
 proc-macro-error = "1"
 quote = "1"
-syn = "1"
+syn = "2"
 rtic-syntax = "1.0.3"
 
 [features]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro2 = "1"
 proc-macro-error = "1"
 quote = "1"
 syn = "2"
-rtic-syntax = "1.0.3"
+rtic-syntax = { git = "https://github.com/rtic-rs/rtic-syntax" }
 
 [features]
 debugprint = []

--- a/macros/src/codegen/local_resources.rs
+++ b/macros/src/codegen/local_resources.rs
@@ -30,7 +30,10 @@ pub fn codegen(
 
         // late resources in `util::link_section_uninit`
         // unless user specifies custom link section
-        let section = if attrs.iter().any(|attr| attr.path.is_ident("link_section")) {
+        let section = if attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("link_section"))
+        {
             None
         } else {
             Some(util::link_section_uninit())

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -27,7 +27,10 @@ pub fn codegen(
 
         // late resources in `util::link_section_uninit`
         // unless user specifies custom link section
-        let section = if attrs.iter().any(|attr| attr.path.is_ident("link_section")) {
+        let section = if attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("link_section"))
+        {
             None
         } else {
             Some(util::link_section_uninit())

--- a/ui/unknown-interrupt.stderr
+++ b/ui/unknown-interrupt.stderr
@@ -1,5 +1,5 @@
-error[E0599]: no variant or associated item named `UnknownInterrupt` found for enum `Interrupt` in the current scope
+error[E0599]: no variant, associated function, or constant named `UnknownInterrupt` found for enum `Interrupt` in the current scope
  --> ui/unknown-interrupt.rs:3:47
   |
 3 | #[rtic::app(device = lm3s6965, dispatchers = [UnknownInterrupt])]
-  |                                               ^^^^^^^^^^^^^^^^ variant or associated item not found in `Interrupt`
+  |                                               ^^^^^^^^^^^^^^^^ variant, associated function, or constant not found in `Interrupt`


### PR DESCRIPTION
Upgrade the dependency `syn` crate to version 2.x. Update the macro parsing code to work with syn 2.x API.

This PR depends on changes in `rtic-syntax`, provided in this PR: https://github.com/rtic-rs/rtic-syntax/pull/94.

These are part of changes to be able to use Rust edition 2024 with RTIC version 1.x.