### PR TITLE
Require T: Send for rtic-sync types

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ## Unreleased
 
+### Fixed
+
+- An `Arbiter<T>` is safely `Send` and `Sync` when `T: Send`.
+
 ## v1.5.0 - 2026-05-30
 
 ### Added

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -11,6 +11,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 - A `Channel<T>` is safely `Send` and `Sync` when `T: Send`.
 - An `Arbiter<T>` is safely `Send` and `Sync` when `T: Send`.
+- `Signal<T>` and `Watch<T>` are safely `Send` and `Sync` when `T: Send`.
 
 ## v1.5.0 - 2026-05-30
 

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 ### Fixed
 
+- A `Channel<T>` is safely `Send` and `Sync` when `T: Send`.
 - An `Arbiter<T>` is safely `Send` and `Sync` when `T: Send`.
 
 ## v1.5.0 - 2026-05-30

--- a/rtic-sync/src/arbiter.rs
+++ b/rtic-sync/src/arbiter.rs
@@ -57,8 +57,8 @@ pub struct Arbiter<T> {
     taken: AtomicBool,
 }
 
-unsafe impl<T> Send for Arbiter<T> {}
-unsafe impl<T> Sync for Arbiter<T> {}
+unsafe impl<T: Send> Send for Arbiter<T> {}
+unsafe impl<T: Send> Sync for Arbiter<T> {}
 
 impl<T> Arbiter<T> {
     /// Create a new arbiter.

--- a/rtic-sync/src/channel.rs
+++ b/rtic-sync/src/channel.rs
@@ -46,9 +46,9 @@ pub struct Channel<T, const N: usize> {
     num_senders: UnsafeCell<usize>,
 }
 
-unsafe impl<T, const N: usize> Send for Channel<T, N> {}
+unsafe impl<T: Send, const N: usize> Send for Channel<T, N> {}
 
-unsafe impl<T, const N: usize> Sync for Channel<T, N> {}
+unsafe impl<T: Send, const N: usize> Sync for Channel<T, N> {}
 
 macro_rules! cs_access {
     ($name:ident, $type:ty) => {
@@ -263,8 +263,6 @@ where
 
 /// A `Sender` can send to the channel and can be cloned.
 pub struct Sender<'a, T, const N: usize>(&'a Channel<T, N>);
-
-unsafe impl<T, const N: usize> Send for Sender<'_, T, N> {}
 
 /// This is needed to make the async closure in `send` accept that we "share"
 /// the link possible between threads.
@@ -564,8 +562,6 @@ impl<T, const N: usize> Clone for Sender<'_, T, N> {
 
 /// A receiver of the channel. There can only be one receiver at any time.
 pub struct Receiver<'a, T, const N: usize>(&'a Channel<T, N>);
-
-unsafe impl<T, const N: usize> Send for Receiver<'_, T, N> {}
 
 impl<T, const N: usize> core::fmt::Debug for Receiver<'_, T, N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -41,8 +41,8 @@ impl<T: Copy> Default for Signal<T> {
     }
 }
 
-unsafe impl<T: Copy> Send for Signal<T> {}
-unsafe impl<T: Copy> Sync for Signal<T> {}
+unsafe impl<T: Copy + Send> Send for Signal<T> {}
+unsafe impl<T: Copy + Send> Sync for Signal<T> {}
 
 impl<T: Copy> Signal<T> {
     /// Create a new signal.

--- a/rtic-sync/src/watch.rs
+++ b/rtic-sync/src/watch.rs
@@ -25,9 +25,6 @@ impl<T: Copy> Default for Watch<T> {
     }
 }
 
-unsafe impl<T: Copy> Send for Watch<T> {}
-unsafe impl<T: Copy> Sync for Watch<T> {}
-
 impl<T: Copy> Watch<T> {
     /// Create a new watch.
     pub const fn new() -> Self {

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -38,6 +38,7 @@ critical-section = "1"
 [dev-dependencies]
 lm3s6965 = "0.2"
 cortex-m-semihosting = "0.5.0"
+rtic-sync = { path = "../rtic-sync" }
 
 [dev-dependencies.futures]
 version = "0.3.26"

--- a/rtic/ui/arbiter-not-send.rs
+++ b/rtic/ui/arbiter-not-send.rs
@@ -1,0 +1,50 @@
+#![no_main]
+
+#[rtic::app(device = lm3s6965, dispatchers = [SSI0, QEI0])]
+mod app {
+    use rtic_sync::arbiter::Arbiter;
+    use std::rc::Rc;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        x: Arbiter<Rc<u32>>,
+        y: Arbiter<Rc<u32>>,
+    }
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        p1::spawn().unwrap();
+        p2::spawn().unwrap();
+
+        let x = Rc::new(5);
+        let y = Rc::clone(&x);
+        (
+            Shared {},
+            Local {
+                x: Arbiter::new(x),
+                y: Arbiter::new(y),
+            },
+        )
+    }
+
+    #[task(priority = 1, local = [x])]
+    async fn p1(cx: p1::Context) -> ! {
+        // Non-atomic update of reference count
+        // through two different Arbiters.
+        let c: Rc<u32> = Rc::clone(&*cx.local.x.access().await);
+        loop {
+            let _ = Rc::clone(&c);
+        }
+    }
+
+    #[task(priority = 2, local = [y])]
+    async fn p2(cx: p2::Context) {
+        let c: Rc<u32> = Rc::clone(&*cx.local.y.access().await);
+        loop {
+            let _ = Rc::clone(&c);
+        }
+    }
+}

--- a/rtic/ui/arbiter-not-send.stderr
+++ b/rtic/ui/arbiter-not-send.stderr
@@ -1,0 +1,13 @@
+error[E0277]: `Rc<u32>` cannot be sent between threads safely
+  --> ui/arbiter-not-send.rs:13:12
+   |
+13 |         x: Arbiter<Rc<u32>>,
+   |            ^^^^^^^^^^^^^^^^ `Rc<u32>` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `Rc<u32>`
+   = note: required for `Arbiter<Rc<u32>>` to implement `Send`
+note: required by a bound in `rtic::export::assert_send`
+  --> src/export.rs
+   |
+   | pub fn assert_send<T: Send>() {}
+   |                       ^^^^ required by this bound in `assert_send`

--- a/rtic/ui/arbiter-not-sync.rs
+++ b/rtic/ui/arbiter-not-sync.rs
@@ -1,0 +1,53 @@
+#![no_main]
+
+#[rtic::app(device = lm3s6965)]
+mod app {
+    use rtic_sync::arbiter::Arbiter;
+    use std::rc::Rc;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {}
+
+    static A: Arbiter<Option<Rc<u32>>> = Arbiter::new(None);
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        A.try_access().unwrap().replace(Rc::new(0));
+        (Shared {}, Local {})
+    }
+
+    #[task(binds = QEI0, priority = 1)]
+    fn p1(_: p1::Context) {
+        let c: Rc<u32> = loop {
+            if let Some(e) = A.try_access()
+                && let Some(c) = &*e
+            {
+                // First clone taken with lock.
+                break Rc::clone(c);
+            };
+        };
+        loop {
+            // Subsequent clones without lock.
+            // Non-atomic updates on reference
+            // count across tasks.
+            let _ = Rc::clone(&c);
+        }
+    }
+
+    #[task(binds = SSI0, priority = 2)]
+    fn p2(_: p2::Context) {
+        let c: Rc<u32> = loop {
+            if let Some(e) = A.try_access()
+                && let Some(c) = &*e
+            {
+                break Rc::clone(c);
+            };
+        };
+        loop {
+            let _ = Rc::clone(&c);
+        }
+    }
+}

--- a/rtic/ui/arbiter-not-sync.stderr
+++ b/rtic/ui/arbiter-not-sync.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `Rc<u32>` cannot be sent between threads safely
+  --> ui/arbiter-not-sync.rs:14:15
+   |
+14 |     static A: Arbiter<Option<Rc<u32>>> = Arbiter::new(None);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<u32>` cannot be sent between threads safely
+   |
+   = help: within `Option<Rc<u32>>`, the trait `Send` is not implemented for `Rc<u32>`
+note: required because it appears within the type `Option<Rc<u32>>`
+  --> $RUST/core/src/option.rs
+   |
+   | pub enum Option<T> {
+   |          ^^^^^^
+   = note: required for `Arbiter<Option<Rc<u32>>>` to implement `Sync`
+   = note: shared static variables must have a type that implements `Sync`

--- a/rtic/ui/channel-not-sync.rs
+++ b/rtic/ui/channel-not-sync.rs
@@ -1,0 +1,53 @@
+#![no_main]
+
+#[rtic::app(device = lm3s6965, dispatchers = [QEI0])]
+mod app {
+    use rtic_sync::channel::{Channel, Receiver, Sender};
+    use std::cell::RefCell;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        r: Receiver<'static, NotSend, 1>,
+        w: Sender<'static, NotSend, 1>,
+    }
+
+    type NotSend = &'static RefCell<u32>;
+
+    #[init(local = [ch: Channel<NotSend, 1> = Channel::new()])]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let (w, r) = cx.local.ch.split();
+        (Shared {}, Local { r, w })
+    }
+
+    #[idle(local = [w, c: RefCell<u32> = RefCell::new(0)])]
+    fn idle(cx: idle::Context) -> ! {
+        // Copy c into the channel, making it
+        // accessible to another task / thread.
+        let c: &'static RefCell<u32> = cx.local.c;
+        cx.local.w.try_send(c).unwrap();
+
+        loop {
+            let mut b = c.borrow_mut();
+
+            // Exclusive borrow in one task.
+            let x: &mut u32 = &mut *b;
+            *x += 1;
+            p2::spawn().unwrap();
+            *x += 1;
+        }
+    }
+
+    #[task(priority = 2, local = [r])]
+    async fn p2(cx: p2::Context) {
+        let c = cx.local.r.recv().await.unwrap();
+        let mut b = c.borrow_mut();
+
+        // Exclusive borrow in another task
+        // without proper locking.
+        let x: &mut u32 = &mut *b;
+        *x += 1;
+    }
+}

--- a/rtic/ui/channel-not-sync.stderr
+++ b/rtic/ui/channel-not-sync.stderr
@@ -1,0 +1,22 @@
+error[E0277]: `RefCell<u32>` cannot be shared between threads safely
+  --> ui/channel-not-sync.rs:13:12
+   |
+13 |         r: Receiver<'static, NotSend, 1>,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `RefCell<u32>` cannot be shared between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `RefCell<u32>`
+   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
+   = note: required for `&'static RefCell<u32>` to implement `Send`
+   = note: required for `Channel<&'static RefCell<u32>, 1>` to implement `Sync`
+   = note: 1 redundant requirement hidden
+   = note: required for `&'static Channel<&'static RefCell<u32>, 1>` to implement `Send`
+note: required because it appears within the type `rtic_sync::channel::Receiver<'static, &'static RefCell<u32>, 1>`
+  --> $WORKSPACE/rtic-sync/src/channel.rs
+   |
+   | pub struct Receiver<'a, T, const N: usize>(&'a Channel<T, N>);
+   |            ^^^^^^^^
+note: required by a bound in `rtic::export::assert_send`
+  --> src/export.rs
+   |
+   | pub fn assert_send<T: Send>() {}
+   |                       ^^^^ required by this bound in `assert_send`

--- a/rtic/ui/signal-not-sync.rs
+++ b/rtic/ui/signal-not-sync.rs
@@ -1,0 +1,53 @@
+#![no_main]
+
+#[rtic::app(device = lm3s6965, dispatchers = [QEI0])]
+mod app {
+    use rtic_sync::signal::{Signal, SignalReader, SignalWriter};
+    use std::cell::RefCell;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        r: SignalReader<'static, CopyNotSend>,
+        w: SignalWriter<'static, CopyNotSend>,
+    }
+
+    type CopyNotSend = Option<&'static RefCell<u32>>;
+
+    #[init(local = [s: Signal<CopyNotSend> = Signal::new()])]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let (w, r) = cx.local.s.split();
+        (Shared {}, Local { r, w })
+    }
+
+    #[idle(local = [w, c: RefCell<u32> = RefCell::new(0)])]
+    fn idle(cx: idle::Context) -> ! {
+        // Copy c into the signal, making it
+        // accessible to another task / thread.
+        let c: &'static RefCell<u32> = cx.local.c;
+        cx.local.w.write(Some(c));
+
+        loop {
+            let mut b = c.borrow_mut();
+
+            // Exclusive borrow in one task.
+            let x: &mut u32 = &mut *b;
+            *x += 1;
+            p2::spawn().unwrap();
+            *x += 1;
+        }
+    }
+
+    #[task(priority = 2, local = [r])]
+    async fn p2(cx: p2::Context) {
+        let c = cx.local.r.wait().await.unwrap();
+        let mut b = c.borrow_mut();
+
+        // Exclusive borrow in another task
+        // without proper locking.
+        let x: &mut u32 = &mut *b;
+        *x += 1;
+    }
+}

--- a/rtic/ui/signal-not-sync.stderr
+++ b/rtic/ui/signal-not-sync.stderr
@@ -1,0 +1,27 @@
+error[E0277]: `RefCell<u32>` cannot be shared between threads safely
+  --> ui/signal-not-sync.rs:13:12
+   |
+13 |         r: SignalReader<'static, CopyNotSend>,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `RefCell<u32>` cannot be shared between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `RefCell<u32>`
+   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
+   = note: required for `&'static RefCell<u32>` to implement `Send`
+note: required because it appears within the type `Option<&'static RefCell<u32>>`
+  --> $RUST/core/src/option.rs
+   |
+   | pub enum Option<T> {
+   |          ^^^^^^
+   = note: required for `Signal<Option<&'static RefCell<u32>>>` to implement `Sync`
+   = note: 1 redundant requirement hidden
+   = note: required for `&'static Signal<Option<&'static RefCell<u32>>>` to implement `Send`
+note: required because it appears within the type `SignalReader<'static, Option<&'static RefCell<u32>>>`
+  --> $WORKSPACE/rtic-sync/src/signal.rs
+   |
+   | pub struct SignalReader<'a, T: Copy> {
+   |            ^^^^^^^^^^^^
+note: required by a bound in `rtic::export::assert_send`
+  --> src/export.rs
+   |
+   | pub fn assert_send<T: Send>() {}
+   |                       ^^^^ required by this bound in `assert_send`


### PR DESCRIPTION
By unconditionally implementing Send and Sync, rtic-sync primitives let us move a !Send type across tasks. To safely implement these traits, we require that T: Send.

See individual commit messages for more information.

I'm using the RTIC UI tests for convenience. Let me know if you prefer putting these rtic-sync tests somewhere else.