### PR TITLE
docs(book): explain monotonics core concept and mention `half_period_counter`

### DIFF
--- a/book/en/src/by-example/delay.md
+++ b/book/en/src/by-example/delay.md
@@ -2,12 +2,17 @@
 
 A convenient way to express miniminal timing requirements is by delaying progression.
 
-This can be achieved by instantiating a monotonic timer (for implementations, see [`rtic-monotonics`]):
+This can be achieved by instantiating a monotonic timer (for implementations, see [`rtic-monotonics`]).
+Monotonics can be thought of like timekeepers, they measure the amount of time elapsed since the start of the monotonic (usually the start of the application). In RTIC, monotonics can be used for delaying the execution of code and for time measurement.
+
+All monotonic implementations in RTIC are guaranteed to remain stable longer than the lifetime of the hardware, i.e. you can theoretically delay a task for multiple years and it should execute successfully (presuming there's no hardware failure). The resolution of the monotonic (i.e. the smallest possible delay that you can sleep) depends on the implementation. Many monotonic implementations also allow you to control the resolution by setting a prescaler for the hardware timer. This is documented in the [crate docs of the individual `rtic-monotonics`](https://docs.rs/rtic-monotonics/latest/rtic_monotonics/#modules).
 
 [`rtic-monotonics`]: https://github.com/rtic-rs/rtic/tree/master/rtic-monotonics
 [`rtic-time`]: https://github.com/rtic-rs/rtic/tree/master/rtic-time
 [`Monotonic`]: https://docs.rs/rtic-time/latest/rtic_time/trait.Monotonic.html
 [Implementing a `Monotonic`]: ../monotonic_impl.md
+
+## Delay
 
 ```rust,noplayground
 ...

--- a/book/en/src/monotonic_impl.md
+++ b/book/en/src/monotonic_impl.md
@@ -8,11 +8,13 @@ The [`rtic-time`] framework is flexible because it can use any timer which has c
 
 For RTIC 2.0, we assume that the user has a time library, e.g. [`fugit`], as the basis for all time-based operations when implementing [`Monotonic`]. These libraries make it much easier to correctly implement the [`Monotonic`] trait, allowing the use of almost any timer in the system for scheduling.
 
-The trait documents the requirements for each method. There are reference implementations available in [`rtic-monotonics`] that can be used for inspriation.
+The trait documents the requirements for each method. There are reference implementations available in [`rtic-monotonics`] that can be used for inspiration.
 
-- [`Systick based`], runs at a fixed interrupt (tick) rate - with some overhead but simple and provides support for large time spans
+- [`Systick based`], runs at a fixed interrupt (core tick) rate - simple, but comes with some overhead and can only be used while the core is running
 - [`RP2040 Timer`], a "proper" implementation with support for waiting for long periods without interrupts. Clearly demonstrates how to use the [`TimerQueue`] to handle scheduling.
 - [`nRF52 timers`] implements monotonic & Timer Queue for the RTC and normal timers in nRF52's
+
+Often, hardware counters only have a width of only 16 or 32 bit, meaning that they would overflow after some minutes to years, depending on the frequency of the counter peripheral. To overcome this issue, monotonic implementations for such counters must use an atomic overflow counter (e.g. [`portable_atomic::AtomicU32`]) to correctly calculate the current time instant. This leads to a race condition between the overflow counter and the time register, which isn't trivial to solve. Hence, a half period counter must be used. Please read and refer to [`rtic_time::half_period_counter`], which provides helper methods and examples for implementing this logic.
 
 ## Contributing
 
@@ -30,9 +32,11 @@ Contributing new implementations of `Monotonic` can be done in multiple ways:
 [`rtic-time::Monotonic`]: https://docs.rs/rtic-time/latest/rtic_time/trait.Monotonic.html
 [`Monotonic`]: https://docs.rs/rtic-time/latest/rtic_time/trait.Monotonic.html
 [`TimerQueue`]: https://docs.rs/rtic-time/latest/rtic_time/timer_queue/struct.TimerQueue.html
+[`rtic_time::half_period_counter`]: https://docs.rs/rtic-time/latest/rtic_time/half_period_counter/
+[`portable_atomic::AtomicU32`]: https://docs.rs/portable-atomic/latest/portable_atomic/struct.AtomicU32.html
 
 ## The timer queue
 
-The timer queue is implemented as a list based priority queue, where list-nodes are statically allocated as part of the  `Future` created when `await`-ing a Future created when waiting for the monotonic. Thus, the timer queue is infallible at run-time (its size and allocation are determined at compile time).
+The timer queue is implemented as a list based priority queue, where list-nodes are statically allocated as part of the `Future` created when `await`-ing a Future created when waiting for the monotonic. Thus, the timer queue is infallible at run-time (its size and allocation are determined at compile time).
 
 Similarly the channels implementation, the timer-queue implementation relies on a global *Critical Section* (CS) for race protection. For the examples a CS implementation is provided by adding `--features test-critical-section` to the build options.


### PR DESCRIPTION
In my opinion the current documentation leaves it unclear what the "core" ideas of monotonics are, and it doesn't mention the `half_period_counter` that probably most peripheral timer implementations need.

This is inspired by the explanations of @Finomnis in #1184.

I'm not 100% happy with it yet, feedback appreciated.