### PR TITLE
Replace shady use of `rustc-cfg=features` with actual CFGs

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,11 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Changed
+
+- Removed explicit `riscv-slic` feature (this was only used to activate functionality shared between `riscv-clint` and `riscv-mecall`).
+- Selecting no or more than one implementation now fails in the build script instead of during compilation.
+
 ## [v2.3.0] - 2026-07-08
 
 ### Fixed

--- a/rtic-macros/Cargo.toml
+++ b/rtic-macros/Cargo.toml
@@ -40,9 +40,8 @@ riscv-esp32c3 = []
 riscv-esp32c6 = []
 # riscv-clic = []
 # riscv-ch32 = []
-riscv-slic = []
-riscv-clint = ["riscv-slic"]
-riscv-mecall= ["riscv-slic"]
+riscv-clint = []
+riscv-mecall = []
 
 # backend API test
 test-template = []

--- a/rtic-macros/build.rs
+++ b/rtic-macros/build.rs
@@ -1,0 +1,21 @@
+fn non_default_features() -> impl Iterator<Item = String> {
+    std::env::vars().filter_map(|(k, _)| {
+        k.strip_prefix("CARGO_FEATURE_")
+            .map(|v| v.to_lowercase().replace("_", "-"))
+            .filter(|f| f != "default")
+    })
+}
+
+fn main() {
+    let features: Vec<_> = non_default_features().collect();
+
+    if features.is_empty() {
+        println!("cargo::error=No backend feature selected.");
+        return;
+    } else if features.len() > 1 {
+        println!("cargo::error=More than one backend selected.");
+        return;
+    }
+
+    println!("cargo::rerun-if-changed=build.rs");
+}

--- a/rtic-macros/build.rs
+++ b/rtic-macros/build.rs
@@ -7,14 +7,22 @@ fn non_default_features() -> impl Iterator<Item = String> {
 }
 
 fn main() {
-    let features: Vec<_> = non_default_features().collect();
+    let mut features: Vec<_> = non_default_features().collect();
 
-    if features.is_empty() {
-        println!("cargo::error=No backend feature selected.");
+    let Some(feature) = features.pop() else {
+        println!("cargo::error=No backend feature selected. Select a backend for `rtic` to resolve this problem.");
         return;
-    } else if features.len() > 1 {
+    };
+
+    if !features.is_empty() {
         println!("cargo::error=More than one backend selected.");
         return;
+    }
+
+    println!("cargo::rustc-check-cfg=cfg(riscv_slic)");
+
+    if feature == "riscv-clint" || feature == "riscv-mecall" {
+        println!("cargo::rustc-cfg=riscv_slic");
     }
 
     println!("cargo::rerun-if-changed=build.rs");

--- a/rtic-macros/src/codegen/bindings.rs
+++ b/rtic-macros/src/codegen/bindings.rs
@@ -22,8 +22,8 @@ pub use esp32c6::*;
 #[cfg(feature = "riscv-esp32c6")]
 mod esp32c6;
 
-#[cfg(feature = "riscv-slic")]
+#[cfg(riscv_slic)]
 pub use riscv_slic::*;
 
-#[cfg(feature = "riscv-slic")]
+#[cfg(riscv_slic)]
 mod riscv_slic;

--- a/rtic-macros/src/codegen/bindings.rs
+++ b/rtic-macros/src/codegen/bindings.rs
@@ -1,13 +1,3 @@
-#[cfg(not(any(
-    feature = "cortex-m-source-masking",
-    feature = "cortex-m-basepri",
-    feature = "test-template",
-    feature = "riscv-esp32c3",
-    feature = "riscv-esp32c6",
-    feature = "riscv-slic",
-)))]
-compile_error!("No backend selected");
-
 #[cfg(any(feature = "cortex-m-source-masking", feature = "cortex-m-basepri"))]
 pub use cortex::*;
 

--- a/rtic-macros/src/codegen/hardware_tasks.rs
+++ b/rtic-macros/src/codegen/hardware_tasks.rs
@@ -2,7 +2,7 @@ use crate::syntax::{ast::App, Context};
 use crate::{
     analyze::Analysis,
     codegen::{
-        bindings::{interrupt_entry, interrupt_exit, handler_config},
+        bindings::{handler_config, interrupt_entry, interrupt_exit},
         local_resources_struct, module, shared_resources_struct,
     },
 };

--- a/rtic-macros/src/codegen/software_tasks.rs
+++ b/rtic-macros/src/codegen/software_tasks.rs
@@ -37,8 +37,16 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
             let cfgs = &task.cfgs;
             let stmts = &task.stmts;
             let inputs = &task.inputs;
-            let lifetime = if task.is_bottom { quote!('static) } else { quote!('a) };
-            let generics = if task.is_bottom { quote!() } else { quote!(<'a>) };
+            let lifetime = if task.is_bottom {
+                quote!('static)
+            } else {
+                quote!('a)
+            };
+            let generics = if task.is_bottom {
+                quote!()
+            } else {
+                quote!(<'a>)
+            };
 
             user_tasks.push(quote!(
                 #(#attrs)*

--- a/rtic-macros/src/lib.rs
+++ b/rtic-macros/src/lib.rs
@@ -3,123 +3,94 @@
     html_favicon_url = "https://raw.githubusercontent.com/rtic-rs/rtic/master/book/en/src/RTIC.svg"
 )]
 
-macro_rules! with_backend {
-    (mod: [$($mod:tt),*]) => {
-        $(
-            with_backend!{ mod $mod; }
-        )*
-    };
-    ($($tokens:tt)*) => {
-        #[cfg(any(
-            feature = "cortex-m-source-masking",
-            feature = "cortex-m-basepri",
-            feature = "test-template",
-            feature = "riscv-esp32c3",
-            feature = "riscv-esp32c6",
-            feature = "riscv-slic",
-        ))]
-        $($tokens)*
-    };
-}
+mod analyze;
+mod check;
+mod codegen;
+mod preprocess;
+mod syntax;
+use proc_macro::TokenStream;
+use std::{env, fs, path::Path};
 
-with_backend! { mod: [analyze, check, codegen, preprocess, syntax] }
-with_backend! { use std::{fs, env, path::Path}; }
-with_backend! { use proc_macro::TokenStream; }
-
-with_backend! {
-    // Used for mocking the API in testing
-    #[doc(hidden)]
-    #[proc_macro_attribute]
-    pub fn mock_app(args: TokenStream, input: TokenStream) -> TokenStream {
-        if let Err(e) = syntax::parse(args, input) {
-            e.to_compile_error().into()
-        } else {
-            "fn main() {}".parse().unwrap()
-        }
+// Used for mocking the API in testing
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn mock_app(args: TokenStream, input: TokenStream) -> TokenStream {
+    if let Err(e) = syntax::parse(args, input) {
+        e.to_compile_error().into()
+    } else {
+        "fn main() {}".parse().unwrap()
     }
 }
 
-with_backend! {
-    /// Attribute used to declare a RTIC application
-    ///
-    /// For user documentation see the [RTIC book](https://rtic.rs)
-    ///
-    /// # Panics
-    ///
-    /// Should never panic, cargo feeds a path which is later converted to a string
-    #[proc_macro_attribute]
-    pub fn app(_args: TokenStream, _input: TokenStream) -> TokenStream {
-        let (mut app, analysis) = match syntax::parse(_args, _input) {
-            Err(e) => return e.to_compile_error().into(),
-            Ok(x) => x,
-        };
+/// Attribute used to declare a RTIC application
+///
+/// For user documentation see the [RTIC book](https://rtic.rs)
+///
+/// # Panics
+///
+/// Should never panic, cargo feeds a path which is later converted to a string
+#[proc_macro_attribute]
+pub fn app(_args: TokenStream, _input: TokenStream) -> TokenStream {
+    let (mut app, analysis) = match syntax::parse(_args, _input) {
+        Err(e) => return e.to_compile_error().into(),
+        Ok(x) => x,
+    };
 
-        // Modify app based on backend before continuing
-        if let Err(e) = preprocess::app(&mut app, &analysis) {
-            return e.to_compile_error().into();
-        }
-        let app = app;
-        // App is not mutable after this point
+    // Modify app based on backend before continuing
+    if let Err(e) = preprocess::app(&mut app, &analysis) {
+        return e.to_compile_error().into();
+    }
+    let app = app;
+    // App is not mutable after this point
 
-        if let Err(e) = check::app(&app, &analysis) {
-            return e.to_compile_error().into();
-        }
+    if let Err(e) = check::app(&app, &analysis) {
+        return e.to_compile_error().into();
+    }
 
-        let analysis = analyze::app(analysis, &app);
+    let analysis = analyze::app(analysis, &app);
 
-        let ts = codegen::app(&app, &analysis);
+    let ts = codegen::app(&app, &analysis);
 
-        // Default output path: <project_dir>/target/
-        let mut out_dir = Path::new("target");
+    // Default output path: <project_dir>/target/
+    let mut out_dir = Path::new("target");
 
-        // Get output directory from Cargo environment
-        // TODO don't want to break builds if OUT_DIR is not set, is this ever the case?
-        let out_str = env::var("OUT_DIR").unwrap_or_else(|_| "".to_string());
+    // Get output directory from Cargo environment
+    // TODO don't want to break builds if OUT_DIR is not set, is this ever the case?
+    let out_str = env::var("OUT_DIR").unwrap_or_else(|_| "".to_string());
 
-        if !out_dir.exists() {
-            // Set out_dir to OUT_DIR
-            out_dir = Path::new(&out_str);
+    if !out_dir.exists() {
+        // Set out_dir to OUT_DIR
+        out_dir = Path::new(&out_str);
 
-            // Default build path, annotated below:
-            // $(pwd)/target/thumbv7em-none-eabihf/debug/build/rtic-<HASH>/out/
-            // <project_dir>/<target-dir>/<TARGET>/debug/build/rtic-<HASH>/out/
-            //
-            // traverse up to first occurrence of TARGET, approximated with starts_with("thumbv")
-            // and use the parent() of this path
-            //
-            // If no "target" directory is found, <project_dir>/<out_dir_root> is used
-            for path in out_dir.ancestors() {
-                if let Some(dir) = path.components().next_back() {
-                    let dir = dir.as_os_str().to_str().unwrap();
+        // Default build path, annotated below:
+        // $(pwd)/target/thumbv7em-none-eabihf/debug/build/rtic-<HASH>/out/
+        // <project_dir>/<target-dir>/<TARGET>/debug/build/rtic-<HASH>/out/
+        //
+        // traverse up to first occurrence of TARGET, approximated with starts_with("thumbv")
+        // and use the parent() of this path
+        //
+        // If no "target" directory is found, <project_dir>/<out_dir_root> is used
+        for path in out_dir.ancestors() {
+            if let Some(dir) = path.components().next_back() {
+                let dir = dir.as_os_str().to_str().unwrap();
 
-                    if dir.starts_with("thumbv") || dir.starts_with("riscv") {
-                        if let Some(out) = path.parent() {
-                            out_dir = out;
-                            break;
-                        }
-                        // If no parent, just use it
-                        out_dir = path;
+                if dir.starts_with("thumbv") || dir.starts_with("riscv") {
+                    if let Some(out) = path.parent() {
+                        out_dir = out;
                         break;
                     }
+                    // If no parent, just use it
+                    out_dir = path;
+                    break;
                 }
             }
         }
-
-        // Try to write the expanded code to disk
-        if let Some(out_str) = out_dir.to_str() {
-            fs::write(format!("{out_str}/rtic-expansion.rs"), ts.to_string()).ok();
-        }
-
-        ts.into()
     }
-}
 
-#[cfg(not(any(
-    feature = "cortex-m-source-masking",
-    feature = "cortex-m-basepri",
-    feature = "test-template",
-    feature = "riscv-esp32c3",
-    feature = "riscv-esp32c6",
-    feature = "riscv-slic",
-)))]
-compile_error!("Cannot compile. No backend feature selected.");
+    // Try to write the expanded code to disk
+    if let Some(out_str) = out_dir.to_str() {
+        fs::write(format!("{out_str}/rtic-expansion.rs"), ts.to_string()).ok();
+    }
+
+    ts.into()
+}

--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -258,7 +258,7 @@ pub struct SoftwareTaskArgs {
     pub shared_resources: SharedResources,
 
     /// Local tasks
-    /// 
+    ///
     /// Local tasks can only be spawned from the same executor.
     /// However they do not require Send and Sync
     pub local_task: bool,

--- a/rtic-macros/src/syntax/backend.rs
+++ b/rtic-macros/src/syntax/backend.rs
@@ -10,7 +10,7 @@ pub use esp32c3::*;
 #[cfg(feature = "riscv-esp32c6")]
 pub use esp32c6::*;
 
-#[cfg(feature = "riscv-slic")]
+#[cfg(riscv_slic)]
 pub use riscv_slic::*;
 
 #[cfg(any(feature = "cortex-m-source-masking", feature = "cortex-m-basepri"))]
@@ -25,5 +25,5 @@ mod esp32c3;
 #[cfg(feature = "riscv-esp32c6")]
 mod esp32c6;
 
-#[cfg(feature = "riscv-slic")]
+#[cfg(riscv_slic)]
 mod riscv_slic;

--- a/rtic-macros/src/syntax/backend.rs
+++ b/rtic-macros/src/syntax/backend.rs
@@ -1,13 +1,3 @@
-#[cfg(not(any(
-    feature = "cortex-m-source-masking",
-    feature = "cortex-m-basepri",
-    feature = "test-template",
-    feature = "riscv-esp32c3",
-    feature = "riscv-esp32c6",
-    feature = "riscv-slic",
-)))]
-compile_error!("No backend selected");
-
 #[cfg(any(feature = "cortex-m-source-masking", feature = "cortex-m-basepri"))]
 pub use cortex::*;
 

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -20,6 +20,10 @@ Example:
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `cortex-m`, `esp32c3`, `esp32c6`, `riscv`, and `riscv-slic` features. These were all implicit features from dependencies that should only be activated by selecting a backend.
+
 ## [v2.3.0] - 2026-07-08
 
 ### Added

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -54,21 +54,23 @@ trybuild = "1"
 
 [features]
 default = []
-thumbv6-backend = ["cortex-m", "rtic-macros/cortex-m-source-masking"]
-thumbv7-backend = ["cortex-m", "rtic-macros/cortex-m-basepri"]
-thumbv8base-backend = ["cortex-m", "rtic-macros/cortex-m-source-masking"]
-thumbv8main-backend = ["cortex-m", "rtic-macros/cortex-m-basepri"]
+thumbv6-backend = ["dep:cortex-m", "rtic-macros/cortex-m-source-masking"]
+thumbv7-backend = ["dep:cortex-m", "rtic-macros/cortex-m-basepri"]
+thumbv8base-backend = ["dep:cortex-m", "rtic-macros/cortex-m-source-masking"]
+thumbv8main-backend = ["dep:cortex-m", "rtic-macros/cortex-m-basepri"]
 # riscv-clic-backend = ["rtic-macros/riscv-clic"]
 # riscv-ch32-backend = ["rtic-macros/riscv-ch32"]
-riscv-esp32c3-backend = ["esp32c3", "riscv", "rtic-macros/riscv-esp32c3"]
-riscv-esp32c6-backend = ["esp32c6", "riscv", "rtic-macros/riscv-esp32c6"]
+riscv-esp32c3-backend = ["dep:esp32c3", "dep:riscv", "rtic-macros/riscv-esp32c3"]
+riscv-esp32c6-backend = ["dep:esp32c6", "dep:riscv", "rtic-macros/riscv-esp32c6"]
 riscv-clint-backend = [
-  "riscv",
+  "dep:riscv",
+  "dep:riscv-slic",
   "riscv-slic/clint-backend",
   "rtic-macros/riscv-clint",
 ]
 riscv-mecall-backend = [
-  "riscv",
+  "dep:riscv",
+  "dep:riscv-slic",
   "riscv-slic/mecall-backend",
   "rtic-macros/riscv-mecall",
 ]

--- a/rtic/build.rs
+++ b/rtic/build.rs
@@ -1,42 +1,56 @@
 use std::env;
 
+fn backends() -> impl Iterator<Item = String> {
+    env::vars().filter_map(|(k, _)| {
+        k.strip_prefix("CARGO_FEATURE_").and_then(|f| {
+            f.ends_with("BACKEND")
+                .then_some(f.to_lowercase().replace("_", "-"))
+        })
+    })
+}
+
 fn main() {
     // Get the backend feature selected by the user
-    let mut backends: Vec<_> = env::vars()
-        .filter_map(|(key, _value)| {
-            if key.starts_with("CARGO_FEATURE") && key.ends_with("BACKEND") {
-                // strip 'CARGO_FEATURE_', convert to lowercase, and replace '_' with '-'
-                Some(key[14..].to_lowercase().replace('_', "-"))
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut backends: Vec<_> = backends().collect();
+
     if backends.len() > 1 {
-        panic!("More than one backend feature selected: {backends:?}");
-    }
-    let backend = backends.pop().expect("No backend feature selected.");
-
-    match backend.as_str() {
-        "thumbv6-backend" | "thumbv8base-backend" => {
-            println!("cargo:rustc-cfg=feature=\"cortex-m-source-masking\"");
-        }
-        "thumbv7-backend" | "thumbv8main-backend" => {
-            println!("cargo:rustc-cfg=feature=\"cortex-m-basepri\"");
-        }
-        "riscv-esp32c3-backend" => {
-            println!("cargo:rustc-cfg=feature=\"riscv-esp32c3\"");
-        }
-        "riscv-esp32c6-backend" => {
-            println!("cargo:rustc-cfg=feature=\"riscv-esp32c6\"");
-        }
-        "riscv-clint-backend" | "riscv-mecall-backend" => {
-            println!("cargo:rustc-cfg=feature=\"riscv-slic\"");
-        }
-        _ => {
-            panic!("Unknown backend feature: {backend:?}");
-        }
+        println!("cargo::error=More than one backend selected: {backends:?}");
+        return;
     }
 
-    println!("cargo:rerun-if-changed=build.rs");
+    let Some(backend) = backends.pop() else {
+        println!("cargo::error=No backend feature selected");
+        return;
+    };
+
+    let features = [
+        ("thumbv6-backend", "cortex-m-source-masking"),
+        ("thumbv8base-backend", "cortex-m-source-masking"),
+        ("thumbv7-backend", "cortex-m-basepri"),
+        ("thumbv8main-backend", "cortex-m-basepri"),
+        ("riscv-esp32c3-backend", "riscv-esp32c3"),
+        ("riscv-esp32c6-backend", "riscv-esp32c6"),
+        ("riscv-clint-backend", "riscv-slic"),
+        ("riscv-mecall-backend", "riscv-slic"),
+    ];
+
+    let cfg_values: Vec<_> = features
+        .iter()
+        .map(|(_feature, cfg)| format!("\"{cfg}\""))
+        .collect();
+
+    let values = cfg_values.join(",");
+    println!("cargo::rustc-check-cfg=cfg(feature, values({}))", values);
+
+    if let Some(feature) = features
+        .iter()
+        .find_map(|(in_feature, out_feature)| (in_feature == &backend).then_some(out_feature))
+    {
+        println!("cargo::rustc-cfg=feature=\"{feature}\"");
+    } else {
+        println!("cargo::error=Unknown backend: {backend}");
+        return;
+    }
+
+    println!("cargo::rerun-if-changed=build.rs");
 }

--- a/rtic/build.rs
+++ b/rtic/build.rs
@@ -23,7 +23,7 @@ fn main() {
         return;
     };
 
-    let features = [
+    let impls = [
         ("thumbv6-backend", "cortex-m-source-masking"),
         ("thumbv8base-backend", "cortex-m-source-masking"),
         ("thumbv7-backend", "cortex-m-basepri"),
@@ -34,19 +34,22 @@ fn main() {
         ("riscv-mecall-backend", "riscv-slic"),
     ];
 
-    let cfg_values: Vec<_> = features
+    let cfg_values: Vec<_> = impls
         .iter()
         .map(|(_feature, cfg)| format!("\"{cfg}\""))
         .collect();
 
     let values = cfg_values.join(",");
-    println!("cargo::rustc-check-cfg=cfg(feature, values({}))", values);
+    println!(
+        "cargo::rustc-check-cfg=cfg(implementation, values({}))",
+        values
+    );
 
-    if let Some(feature) = features
+    if let Some(feature) = impls
         .iter()
-        .find_map(|(in_feature, out_feature)| (in_feature == &backend).then_some(out_feature))
+        .find_map(|(feature, implementation)| (feature == &backend).then_some(implementation))
     {
-        println!("cargo::rustc-cfg=feature=\"{feature}\"");
+        println!("cargo::rustc-cfg=implementation=\"{feature}\"");
     } else {
         println!("cargo::error=Unknown backend: {backend}");
         return;

--- a/rtic/src/export.rs
+++ b/rtic/src/export.rs
@@ -11,17 +11,17 @@ pub use cortex_common::*;
 mod cortex_common;
 
 // Cortex-M target with basepri support
-#[cfg(feature = "cortex-m-basepri")]
+#[cfg(implementation = "cortex-m-basepri")]
 mod cortex_basepri;
 
-#[cfg(feature = "cortex-m-basepri")]
+#[cfg(implementation = "cortex-m-basepri")]
 pub use cortex_basepri::*;
 
 // Cortex-M target with source mask support
-#[cfg(feature = "cortex-m-source-masking")]
+#[cfg(implementation = "cortex-m-source-masking")]
 mod cortex_source_mask;
 
-#[cfg(feature = "cortex-m-source-masking")]
+#[cfg(implementation = "cortex-m-source-masking")]
 pub use cortex_source_mask::*;
 
 #[cfg(feature = "riscv")]
@@ -30,19 +30,19 @@ pub mod riscv_common;
 #[cfg(feature = "riscv")]
 pub use riscv_common::*;
 
-#[cfg(feature = "riscv-esp32c3")]
+#[cfg(implementation = "riscv-esp32c3")]
 mod riscv_esp32c3;
-#[cfg(feature = "riscv-esp32c3")]
+#[cfg(implementation = "riscv-esp32c3")]
 pub use riscv_esp32c3::*;
 
-#[cfg(feature = "riscv-esp32c6")]
+#[cfg(implementation = "riscv-esp32c6")]
 mod riscv_esp32c6;
-#[cfg(feature = "riscv-esp32c6")]
+#[cfg(implementation = "riscv-esp32c6")]
 pub use riscv_esp32c6::*;
 
-#[cfg(feature = "riscv-slic")]
+#[cfg(implementation = "riscv-slic")]
 mod slic;
-#[cfg(feature = "riscv-slic")]
+#[cfg(implementation = "riscv-slic")]
 pub use slic::*;
 
 #[inline(always)]

--- a/rtic/src/export.rs
+++ b/rtic/src/export.rs
@@ -4,10 +4,16 @@ pub use portable_atomic as atomic;
 pub mod executor;
 
 // Cortex-M target (any)
-#[cfg(feature = "cortex-m")]
+#[cfg(any(
+    implementation = "cortex-m-basepri",
+    implementation = "cortex-m-source-masking"
+))]
 pub use cortex_common::*;
 
-#[cfg(feature = "cortex-m")]
+#[cfg(any(
+    implementation = "cortex-m-basepri",
+    implementation = "cortex-m-source-masking"
+))]
 mod cortex_common;
 
 // Cortex-M target with basepri support
@@ -24,10 +30,18 @@ mod cortex_source_mask;
 #[cfg(implementation = "cortex-m-source-masking")]
 pub use cortex_source_mask::*;
 
-#[cfg(feature = "riscv")]
+#[cfg(any(
+    implementation = "riscv-esp32c3",
+    implementation = "riscv-esp32c6",
+    implementation = "riscv-slic"
+))]
 pub mod riscv_common;
 
-#[cfg(feature = "riscv")]
+#[cfg(any(
+    implementation = "riscv-esp32c3",
+    implementation = "riscv-esp32c6",
+    implementation = "riscv-slic"
+))]
 pub use riscv_common::*;
 
 #[cfg(implementation = "riscv-esp32c3")]

--- a/rtic/src/export/cortex_basepri.rs
+++ b/rtic/src/export/cortex_basepri.rs
@@ -7,11 +7,6 @@ pub use cortex_m::{
     peripheral::{DWT, SCB, SYST, scb::SystemHandler},
 };
 
-#[cfg(not(any(feature = "thumbv7-backend", feature = "thumbv8main-backend")))]
-compile_error!(
-    "Building for Cortex-M with basepri, but 'thumbv7-backend' or 'thumbv8main-backend' backend not selected"
-);
-
 #[inline(always)]
 pub fn run<F>(priority: u8, f: F)
 where

--- a/rtic/src/export/cortex_source_mask.rs
+++ b/rtic/src/export/cortex_source_mask.rs
@@ -5,11 +5,6 @@ pub use cortex_m::{
     peripheral::{DWT, NVIC, SCB, SYST, scb::SystemHandler},
 };
 
-#[cfg(not(any(feature = "thumbv6-backend", feature = "thumbv8base-backend")))]
-compile_error!(
-    "Building for Cortex-M with source masking, but 'thumbv6-backend' or 'thumbv8base-backend' backend not selected"
-);
-
 /// Mask is used to store interrupt masks on systems without a BASEPRI register (M0, M0+, M23).
 /// It needs to be large enough to cover all the relevant interrupts in use.
 /// For M0/M0+ there are only 32 interrupts so we only need one u32 value.

--- a/rtic/src/export/riscv_esp32c3.rs
+++ b/rtic/src/export/riscv_esp32c3.rs
@@ -2,9 +2,6 @@ use esp32c3::INTERRUPT_CORE0;
 pub use esp32c3::{Interrupt, Peripherals};
 pub use riscv::{interrupt, register::mcause};
 
-#[cfg(all(feature = "riscv-esp32c3", not(feature = "riscv-esp32c3-backend")))]
-compile_error!("Building for the esp32c3, but 'riscv-esp32c3-backend not selected'");
-
 #[inline(always)]
 pub fn run<F>(priority: u8, f: F)
 where

--- a/rtic/src/export/riscv_esp32c6.rs
+++ b/rtic/src/export/riscv_esp32c6.rs
@@ -3,9 +3,6 @@ pub use esp32c6::{Interrupt, Peripherals};
 pub use riscv::interrupt;
 pub use riscv::register::mcause;
 
-#[cfg(all(feature = "riscv-esp32c6", not(feature = "riscv-esp32c6-backend")))]
-compile_error!("Building for the esp32c6, but 'riscv-esp32c6-backend not selected'");
-
 #[inline(always)]
 pub fn run<F>(priority: u8, f: F)
 where

--- a/rtic/src/export/slic.rs
+++ b/rtic/src/export/slic.rs
@@ -1,11 +1,5 @@
 pub use riscv_slic::{InterruptNumber, lock, pend, run};
 
-#[cfg(all(
-    feature = "riscv-slic",
-    not(any(feature = "riscv-clint-backend", feature = "riscv-mecall-backend"))
-))]
-compile_error!("Building for the riscv-slic, but no compatible backend selected");
-
 /// USE CASE RE-EXPORTS: needed for SLIC-only
 pub use riscv_slic::{self, codegen, set_priority};
 

--- a/rtic/src/lib.rs
+++ b/rtic/src/lib.rs
@@ -31,7 +31,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/rtic-rs/rtic/master/book/en/src/RTIC.svg"
 )]
 #![allow(clippy::inline_always)]
-#![allow(unexpected_cfgs)]
 
 pub use rtic_core::{Exclusive, Mutex, prelude as mutex_prelude};
 pub use rtic_macros::app;


### PR DESCRIPTION
`rtic` and `rtic-macros` do some shenanigans with activating "features" (that are not activatable by library consumers), and `rtic` has a bunch of optional deps that can be enabled by library consumers.

Additionally, both crates use `compile_error` to convey problems with activating too many/too few features.

Both of these things can (and should) be handled by the build script instead. It prints out a much easier to parse error message, and doesn't even attempt to compile anything. 

This PR performs the suggested replacements, removes a funky `allow` along the way, and is technically breaking: some previously available features (intended only for internal use) have been removed from `rtic` and `rtic-macros`. Compilation will stop working for users of `rtic` that activated one of those features explicitly alongside their backend (i.e. `riscv` + `riscv-mecall-backend`).

To clarify, `rtic`'s feature set sees the following diff (used word-diff in an attempt to make it look a bit more obvious):
<img width="1267" height="241" alt="image" src="https://github.com/user-attachments/assets/ccdeda4f-221b-4cd1-9807-4d558ba9dc99" />

while `rtic-macros` feature set sees the following diff:
<img width="354" height="190" alt="image" src="https://github.com/user-attachments/assets/eeaf25c3-c442-49b0-80ac-cd7db83171df" />

all of the removed features have always been "only activate these dependencies if other features are selected" and "must use in combination with some other feature" types of features: functionality-wise, nothing changes. However, others may have selected these features before. If we want to avoid this kind of breaking change, I can revert the non-`dep:`-to-`dep:` change.