### PR TITLE
rtic-macros: add `#[pre_rtic_hook]` function hook

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ## [Unreleased]
 
+### Added
+
+- `#[pre_rtic_hook]` attribute that allows running code before RTIC initialization.
+
 ## [v2.3.0] - 2026-07-08
 
 ### Fixed

--- a/rtic-macros/src/codegen.rs
+++ b/rtic-macros/src/codegen.rs
@@ -10,6 +10,7 @@ mod assertions;
 mod async_dispatchers;
 mod extra_mods;
 mod hardware_tasks;
+mod pre_rtic_hook;
 mod idle;
 mod init;
 mod local_resources;
@@ -34,6 +35,7 @@ pub fn app(app: &App, analysis: &Analysis) -> TokenStream2 {
     let main = main::codegen(app, analysis);
     let init_codegen = init::codegen(app, analysis);
     let idle_codegen = idle::codegen(app, analysis);
+    let pre_rtic_hook_codegen = pre_rtic_hook::codegen(app, analysis);
     let shared_resources_codegen = shared_resources::codegen(app, analysis);
     let local_resources_codegen = local_resources::codegen(app, analysis);
     let hardware_tasks_codegen = hardware_tasks::codegen(app, analysis);
@@ -66,6 +68,8 @@ pub fn app(app: &App, analysis: &Analysis) -> TokenStream2 {
             #init_codegen
 
             #idle_codegen
+
+            #pre_rtic_hook_codegen
 
             #hardware_tasks_codegen
 

--- a/rtic-macros/src/codegen/main.rs
+++ b/rtic-macros/src/codegen/main.rs
@@ -48,6 +48,14 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
 
     let main = util::suffixed("main");
     let init_name = &app.init.name;
+    let call_pre_rtic_hook = if let Some(pre_rtic_hook) = &app.pre_rtic_hook {
+        let name = &pre_rtic_hook.name;
+        quote!(
+            let _: () = #name();
+        )
+    } else {
+        quote!()
+    };
 
     let init_args = if app.args.core {
         quote!(core.into(), executors_size)
@@ -63,6 +71,8 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
         #[doc(hidden)]
         #[no_mangle]
         unsafe extern "C" fn #main() -> ! {
+            #call_pre_rtic_hook
+
             #(#assertion_stmts)*
 
             #(#pre_init_stmts)*

--- a/rtic-macros/src/codegen/pre_rtic_hook.rs
+++ b/rtic-macros/src/codegen/pre_rtic_hook.rs
@@ -1,0 +1,31 @@
+use crate::syntax::ast::App;
+use crate::{
+    analyze::Analysis,
+};
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+/// Generates the `#[pre_rtic_hook]` function if needed
+pub fn codegen(app: &App, _: &Analysis) -> TokenStream2 {
+    if let Some(pre_rtic_hook) = &app.pre_rtic_hook {
+        let attrs = &pre_rtic_hook.attrs;
+        let name = &pre_rtic_hook.name;
+        let stmts = &pre_rtic_hook.stmts;
+        let user_idle = if !pre_rtic_hook.is_extern {
+            Some(quote!(
+                #(#attrs)*
+                fn #name() {
+                    #(#stmts)*
+                }
+            ))
+        } else {
+            None
+        };
+
+        quote!(
+            #user_idle
+        )
+    } else {
+        quote!()
+    }
+}

--- a/rtic-macros/src/syntax/ast.rs
+++ b/rtic-macros/src/syntax/ast.rs
@@ -44,6 +44,9 @@ pub struct App {
 
     /// Async software tasks: `#[task]`
     pub software_tasks: Map<SoftwareTask>,
+
+    /// The `#[pre_rtic_hook]` function
+    pub pre_rtic_hook: Option<PreRticHook>,
 }
 
 /// Interrupts used to dispatch software tasks
@@ -369,3 +372,21 @@ pub type SharedResources = Map<Access>;
 
 /// Local resource access/declaration list in task attribute
 pub type LocalResources = Map<TaskLocal>;
+
+/// The `#[pre_rtic_hook]` function
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct PreRticHook {
+    /// Attributes that will apply to this `#[pre_rtic_hook]` function
+    pub attrs: Vec<Attribute>,
+
+    /// The name of the `#[pre_rtic_hook]` function
+    pub name: Ident,
+
+    /// The statements that make up this `#[pre_rtic_hook]` function
+    pub stmts: Vec<Stmt>,
+
+    /// The `#[pre_rtic_hook]` function is declared externally
+    pub is_extern: bool,
+}
+

--- a/rtic-macros/src/syntax/parse.rs
+++ b/rtic-macros/src/syntax/parse.rs
@@ -2,6 +2,7 @@ mod app;
 mod hardware_task;
 mod idle;
 mod init;
+mod pre_rtic_hook;
 mod resource;
 mod software_task;
 mod util;

--- a/rtic-macros/src/syntax/parse/app.rs
+++ b/rtic-macros/src/syntax/parse/app.rs
@@ -11,7 +11,7 @@ use syn::{
 use crate::syntax::{
     ast::{
         App, AppArgs, Dispatcher, Dispatchers, HardwareTask, Idle, IdleArgs, Init, InitArgs,
-        LocalResource, SharedResource, SoftwareTask,
+        LocalResource, PreRticHook, SharedResource, SoftwareTask,
     },
     backend::BackendArgs,
     parse::{self as syntax_parse, util},
@@ -191,6 +191,8 @@ impl App {
         let mut seen_idents = HashSet::<Ident>::new();
         let mut bindings = HashSet::<Ident>::new();
 
+        let mut pre_rtic_hook = None;
+
         let mut check_binding = |ident: &Ident| {
             if bindings.contains(ident) {
                 return Err(parse::Error::new(
@@ -297,6 +299,24 @@ impl App {
                                 );
                             }
                         }
+                    } else if let Some(pos) = item
+                        .attrs
+                        .iter()
+                        .position(|attr| util::attr_eq(attr, "pre_rtic_hook"))
+                    {
+                        let _ = item.attrs.remove(pos);
+
+                        // If an pre_rtic_hook function already exists, error
+                        if pre_rtic_hook.is_some() {
+                            return Err(parse::Error::new(
+                                span,
+                                "`#[pre_rtic_hook]` function must appear at most once",
+                            ));
+                        }
+
+                        check_ident(&item.sig.ident)?;
+
+                        pre_rtic_hook = Some(PreRticHook::parse(item)?);
                     } else {
                         // Forward normal functions
                         user_code.push(Item::Fn(item.clone()));
@@ -480,11 +500,29 @@ impl App {
                                         );
                                     }
                                 }
+                            } else if let Some(pos) = item
+                                .attrs
+                                .iter()
+                                .position(|attr| util::attr_eq(attr, "pre_rtic_hook"))
+                            {
+                                let _ = item.attrs.remove(pos);
+
+                                // If an idle function already exists, error
+                                if pre_rtic_hook.is_some() {
+                                    return Err(parse::Error::new(
+                                        span,
+                                        "`#[pre_rtic_hook]` function must appear at most once",
+                                    ));
+                                }
+
+                                check_ident(&item.sig.ident)?;
+
+                                pre_rtic_hook = Some(PreRticHook::parse_foreign(item)?);
                             } else {
                                 return Err(parse::Error::new(
                                     span,
-                                    "`extern` task, init or idle must have either `#[task(..)]`,
-                                    `#[init(..)]` or `#[idle(..)]` attribute",
+                                    "`extern` task, init, pre_rtic_hook or idle must have either `#[task(..)]`,
+                                    `#[init(..)]`, `#[pre_rtic_hook]` or `#[idle(..)]` attribute",
                                 ));
                             }
                         } else {
@@ -544,6 +582,7 @@ impl App {
             user_code,
             hardware_tasks,
             software_tasks,
+            pre_rtic_hook,
         })
     }
 }

--- a/rtic-macros/src/syntax/parse/pre_rtic_hook.rs
+++ b/rtic-macros/src/syntax/parse/pre_rtic_hook.rs
@@ -1,0 +1,45 @@
+use syn::{parse, ForeignItemFn, ItemFn, Stmt};
+
+use crate::syntax::{ast::PreRticHook, parse::util};
+
+impl PreRticHook {
+    pub(crate) fn parse(item: ItemFn) -> parse::Result<Self> {
+        let valid_signature = util::check_fn_signature(&item, false)
+            && item.sig.inputs.len() == 0
+            && util::type_is_unit(&item.sig.output);
+
+        if valid_signature {
+            return Ok(PreRticHook {
+                attrs: item.attrs,
+                name: item.sig.ident,
+                stmts: item.block.stmts,
+                is_extern: false,
+            });
+        }
+
+        Err(parse::Error::new(
+            item.sig.ident.span(),
+            format!("this `#[pre_rtic_hook]` function must have signature `fn()`"),
+        ))
+    }
+
+    pub(crate) fn parse_foreign(item: ForeignItemFn) -> parse::Result<Self> {
+        let valid_signature = util::check_foreign_fn_signature(&item, false)
+            && item.sig.inputs.len() == 0
+            && util::type_is_unit(&item.sig.output);
+
+        if valid_signature {
+            return Ok(PreRticHook {
+                attrs: item.attrs,
+                name: item.sig.ident,
+                stmts: Vec::<Stmt>::new(),
+                is_extern: true,
+            });
+        }
+
+        Err(parse::Error::new(
+            item.sig.ident.span(),
+            format!("this `#[pre_rtic_hook]` function must have signature `fn()`"),
+        ))
+    }
+}


### PR DESCRIPTION
`#[pre_rtic_hook]` hook allows injecting code that runs directly after the jump from reset handler to main, that is right before RTIC starts its self-initialization. Useful for cases when using cortex-m-rt pre-init would be too early (.bss/.data not initialized) while running code in RTIC init would be too late (NVIC preconfigured, executor memory allocated by RTIC-generated `main`).