### PR TITLE
Fix docs.rs for rtic-monotonics

### DIFF
--- a/rtic-monotonics/CHANGELOG.md
+++ b/rtic-monotonics/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
+## v2.2.1 - 2026-07-23
+
+### Fixed
+
+- Fix `docs.rs` build by adding additional silabs features to the set used for `docs.rs` runs.
+
 ## v2.2.0 - 2026-07-23
 
 ### Changed

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtic-monotonics"
-version = "2.2.0"
+version = "2.2.1"
 
 edition = "2021"
 authors = [

--- a/rtic-monotonics/Cargo.toml
+++ b/rtic-monotonics/Cargo.toml
@@ -20,7 +20,8 @@ exclude = ["scripts/**"]
 [package.metadata.docs.rs]
 features = [
     "cortex-m-systick",
-    "silabs",
+    "silabs_timer0",
+    "efr32fg25a021f256im56",
     "rp2040",
     "rp235x",
     "nrf52840",


### PR DESCRIPTION
Fix the docs.rs by replacing the features used for that build.

Also added v2.2.1 release in a separate commit (assuming that we want a release here)

Validated that this works by reproducing the failed run from `docs.rs`, and making the same substitution as I've made in this PR on the command line.