### PR TITLE
rtic-macros: Add missing docs to LocalSpawner struct

### DIFF
--- a/examples/lm3s6965/examples/spawn_local.rs
+++ b/examples/lm3s6965/examples/spawn_local.rs
@@ -1,5 +1,8 @@
+//! examples/spawn_local.rs
+
 #![no_main]
 #![no_std]
+#![deny(missing_docs)]
 
 use panic_semihosting as _;
 
@@ -34,5 +37,6 @@ mod app {
     }
 }
 
+/// A type that cannot cross thread boundaries.
 #[derive(Default, Debug)]
 struct NotSendNotSync(core::marker::PhantomData<*mut u8>);

--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -9,6 +9,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Add missing docs to `LocalSpawner` struct
 - Removed explicit `riscv-slic` feature (this was only used to activate functionality shared between `riscv-clint` and `riscv-mecall`).
 - Selecting no or more than one implementation now fails in the build script instead of during compilation.
 

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -201,12 +201,6 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
             let local_spawner = util::internal_task_ident(t, "LocalSpawner");
             fields.push(quote! {
                 /// Used to spawn tasks on the same executor
-                ///
-                /// This is useful for tasks that take args which are !Send/!Sync.
-                ///
-                /// NOTE: This only works with tasks marked `local_task = true`
-                /// and which have the same priority and thus will run on the
-                /// same executor.
                 pub local_spawner: #local_spawner
             });
             let tasks = local_tasks_on_same_executor
@@ -238,6 +232,13 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
                 .collect::<Vec<_>>();
             values.push(quote!(local_spawner: #local_spawner { _p: core::marker::PhantomData }));
             items.push(quote! {
+                /// Used to spawn tasks on the same executor
+                ///
+                /// This is useful for tasks that take args which are !Send/!Sync.
+                ///
+                /// NOTE: This only works with tasks marked `local_task = true`
+                /// and which have the same priority and thus will run on the
+                /// same executor.
                 pub struct #local_spawner {
                     _p: core::marker::PhantomData<*mut ()>,
                 }


### PR DESCRIPTION
Clippy will complain if it's configured to warn/deny on missing docs and one uses local tasks (`local_task=true`).

Also add `[deny(missing_docs)]` on local task example.