### PR TITLE
rtic-sync: fix a concurrency bug with `SignalWriter::write_inner` + `WatchReader::try_get`

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -12,6 +12,7 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - A `Channel<T>` is safely `Send` and `Sync` when `T: Send`.
 - An `Arbiter<T>` is safely `Send` and `Sync` when `T: Send`.
 - `Signal<T>` and `Watch<T>` are safely `Send` and `Sync` when `T: Send`.
+- Fixed a bug where, in an unlikely edge-case, `WatchReader::changed` could return twice for a single `WatchWriter::write`.
 
 ## v1.5.0 - 2026-05-30
 

--- a/rtic-sync/src/lib.rs
+++ b/rtic-sync/src/lib.rs
@@ -1,6 +1,6 @@
 //! Synchronization primitives for asynchronous contexts.
 
-#![cfg_attr(not(loom), no_std)]
+#![cfg_attr(not(any(loom, test)), no_std)]
 #![deny(missing_docs)]
 
 #[cfg(feature = "defmt-03")]

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -105,8 +105,9 @@ impl<T: Copy> SignalWriter<'_, T> {
             let mut_ptr = self.parent.store.get_mut();
             // SAFETY: in a cs: exclusive access
             let _ = core::mem::replace(unsafe { mut_ptr.deref() }, value);
+
+            self.parent.seen.store(false, Release);
         });
-        self.parent.seen.store(false, Release);
 
         self.parent.waker.wake();
     }

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -1,11 +1,15 @@
 //! A "latest only" value store with unlimited writers and async waiting.
 
-use core::{cell::UnsafeCell, future::poll_fn, task::Poll};
-use portable_atomic::{
-    AtomicBool,
-    Ordering::{AcqRel, Release},
-};
+use crate::unsafecell::UnsafeCell;
+use core::sync::atomic::Ordering::{AcqRel, Release};
+use core::{future::poll_fn, task::Poll};
 use rtic_common::waker_registration::CriticalSectionWakerRegistration;
+
+#[cfg(loom)]
+use loom::sync::atomic::AtomicBool;
+
+#[cfg(not(loom))]
+use portable_atomic::AtomicBool;
 
 /// Basically an Option but for indicating
 /// whether the store has been set or not
@@ -46,7 +50,19 @@ unsafe impl<T: Copy + Send> Sync for Signal<T> {}
 
 impl<T: Copy> Signal<T> {
     /// Create a new signal.
+    #[cfg(not(loom))]
     pub const fn new() -> Self {
+        Self {
+            waker: CriticalSectionWakerRegistration::new(),
+            store: UnsafeCell::new(Store::Unset),
+            seen: AtomicBool::new(false),
+            already_split: AtomicBool::new(false),
+        }
+    }
+
+    /// Create a new signal.
+    #[cfg(loom)]
+    pub fn new() -> Self {
         Self {
             waker: CriticalSectionWakerRegistration::new(),
             store: UnsafeCell::new(Store::Unset),
@@ -86,8 +102,9 @@ impl<T: Copy> SignalWriter<'_, T> {
     /// Write a raw Store value to the Signal.
     pub(crate) fn write_inner(&mut self, value: Store<T>) {
         critical_section::with(|_| {
+            let mut_ptr = self.parent.store.get_mut();
             // SAFETY: in a cs: exclusive access
-            unsafe { self.parent.store.get().replace(value) };
+            let _ = core::mem::replace(unsafe { mut_ptr.deref() }, value);
         });
         self.parent.seen.store(false, Release);
 
@@ -126,8 +143,9 @@ impl<T: Copy> SignalReader<'_, T> {
     /// Immediately read and evict the latest value stored in the Signal.
     fn take(&mut self) -> Store<T> {
         critical_section::with(|_| {
+            let mut_ptr = self.parent.store.get_mut();
             // SAFETY: in a cs: exclusive access
-            unsafe { self.parent.store.get().replace(Store::Unset) }
+            core::mem::replace(unsafe { mut_ptr.deref() }, Store::Unset)
         })
     }
 

--- a/rtic-sync/src/watch.rs
+++ b/rtic-sync/src/watch.rs
@@ -157,6 +157,85 @@ impl<T: Copy> WatchReader<'_, T> {
 }
 
 #[cfg(test)]
+#[cfg(loom)]
+mod loom_tests {
+    use std::future::Future;
+
+    use super::*;
+
+    #[test]
+    fn always_seen() {
+        loom::model(|| {
+            let watch = Box::leak(Box::new(Watch::new()));
+            let (mut writer, mut reader) = watch.split();
+
+            let handle = loom::thread::spawn(move || {
+                let pre_seen = reader.get_seen();
+                let value = reader.try_get();
+                let post_seen = reader.get_seen();
+
+                if let Some(value) = value {
+                    // If we get a value from a single write, we
+                    // 1. Expect it to be correct
+                    assert_eq!(value, 0x1337_1337);
+                    // 2. Expect not to have seen any value beforehand
+                    assert!(!pre_seen);
+                    // 3. Expect to have seen the value afterwards
+                    assert!(post_seen);
+                } else {
+                    // If we don't get a value from a single write, we
+                    // 1. Expect not to have seen any value beforehand
+                    assert!(!pre_seen);
+                    // 2. And expecct not to have seen any value afterwards
+                    assert!(!post_seen);
+                }
+            });
+
+            writer.write(0x1337_1337);
+
+            handle.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn changed_always_seen() {
+        loom::model(|| {
+            let watch = Box::leak(Box::new(Watch::new()));
+            let (mut writer, mut reader) = watch.split();
+
+            let handle = loom::thread::spawn(move || {
+                let waker = core::task::Waker::noop();
+                let mut cx = core::task::Context::from_waker(waker);
+
+                let pre_seen = reader.get_seen();
+                let value = { core::pin::pin!(reader.changed()).as_mut().poll(&mut cx) };
+                let post_seen = reader.get_seen();
+
+                if let Poll::Ready(value) = value {
+                    // If we get a value from a single write, we
+                    // 1. Expect it to be correct
+                    assert_eq!(value, 0x1337_1337);
+                    // 2. Expect not to have seen any value beforehand
+                    assert!(!pre_seen);
+                    // 3. Expect to have seen the value afterwards
+                    assert!(post_seen);
+                } else {
+                    // If we don't get a value from a single write, we
+                    // 1. Expect not to have seen any value beforehand
+                    assert!(!pre_seen);
+                    // 2. And expecct not to have seen any value afterwards
+                    assert!(!post_seen);
+                }
+            });
+
+            writer.write(0x1337_1337);
+
+            handle.join().unwrap();
+        });
+    }
+}
+
+#[cfg(test)]
 #[cfg(not(loom))]
 mod tests {
     use super::*;

--- a/rtic-sync/src/watch.rs
+++ b/rtic-sync/src/watch.rs
@@ -1,8 +1,8 @@
 //! A "latest only" value store with unlimited writers and async waiting. Value is always available once initialized.
 
 use crate::signal::{Signal, SignalWriter, Store};
+use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::{future::poll_fn, task::Poll};
-use portable_atomic::Ordering::{AcqRel, Acquire, Release};
 
 /// A "latest only" value store with unlimited writers and async waiting. Value is always available once initialized.
 pub struct Watch<T: Copy>(Signal<T>);
@@ -27,7 +27,14 @@ impl<T: Copy> Default for Watch<T> {
 
 impl<T: Copy> Watch<T> {
     /// Create a new watch.
+    #[cfg(not(loom))]
     pub const fn new() -> Self {
+        Self(Signal::new())
+    }
+
+    /// Create a new watch.
+    #[cfg(loom)]
+    pub fn new() -> Self {
         Self(Signal::new())
     }
 
@@ -97,8 +104,9 @@ impl<T: Copy> WatchReader<'_, T> {
     /// Immediately get the latest value stored in the Signal.
     fn get_inner(&mut self) -> Store<T> {
         critical_section::with(|_| {
+            let mut_ptr = self.parent.store.get_mut();
             // SAFETY: in a cs: exclusive access
-            unsafe { self.parent.store.get().read() }
+            unsafe { *mut_ptr.deref() }
         })
     }
 


### PR DESCRIPTION
The flow for this bug is:

1. `SignalWriter::write_inner` writes a value to the `Store`
2. `SignalWriter::write_inner` gets preempted by `WatchReader::try_get`
3. `WatchReader::try_get` reads the value from the `Store`
4. `WatchReader::mark_seen` marks the value as seen
5. `SignalWriter::write_inner` resumes, and marks the value as unseen

<del>I am fairly certain there is another bug lurking in the `changed` function: I feel like there is an inconsistency w.r.t. waking a second time, as the waker access and `seen` accesses are not synchronized in any way. That will land in another PR, though :)</del> Ah, okay: the `changed` function was affected by the exact same bug, but with this change it is also fixed. I've added a test for that as well (though it is largely the same).

This change is important as, without it, one cannot trust that `changed` will _only_ return if a change occurs: due to this bug, it can return twice for a single change, which is counter-intuitive and not what the API promises ("If current value is already seen, it will wait for a new value to be written")