### PR TITLE
rtic-sync: watch: add `reader` and `writer` functions

### DIFF
--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -14,6 +14,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 - `Signal<T>` and `Watch<T>` are safely `Send` and `Sync` when `T: Send`.
 - Fixed a bug where, in an unlikely edge-case, `WatchReader::changed` could return twice for a single `WatchWriter::write`.
 
+### Added
+
+- One can now obtain `Reader`s and `Writer`s for a `Watch` and `Signal` individually (i.e. without calling `split()`), and if a `Reader` is dropped it may be recreated.
+
 ## v1.5.0 - 2026-05-30
 
 ### Added

--- a/rtic-sync/src/signal.rs
+++ b/rtic-sync/src/signal.rs
@@ -24,7 +24,7 @@ pub struct Signal<T: Copy> {
     pub(crate) waker: CriticalSectionWakerRegistration,
     pub(crate) store: UnsafeCell<Store<T>>,
     pub(crate) seen: AtomicBool,
-    pub(crate) already_split: AtomicBool,
+    pub(crate) reader_alive: AtomicBool,
 }
 
 impl<T> core::fmt::Debug for Signal<T>
@@ -56,7 +56,7 @@ impl<T: Copy> Signal<T> {
             waker: CriticalSectionWakerRegistration::new(),
             store: UnsafeCell::new(Store::Unset),
             seen: AtomicBool::new(false),
-            already_split: AtomicBool::new(false),
+            reader_alive: AtomicBool::new(false),
         }
     }
 
@@ -67,16 +67,53 @@ impl<T: Copy> Signal<T> {
             waker: CriticalSectionWakerRegistration::new(),
             store: UnsafeCell::new(Store::Unset),
             seen: AtomicBool::new(false),
-            already_split: AtomicBool::new(false),
+            reader_alive: AtomicBool::new(false),
         }
     }
 
     /// Split the signal into a writer and reader.
+    ///
+    /// # Panics
+    /// This function calls [`Self::take_reader`] and has the same
+    /// panicking behaviour.
     pub fn split(&self) -> (SignalWriter<'_, T>, SignalReader<'_, T>) {
-        if self.already_split.swap(true, AcqRel) {
-            panic!("`Signal` cannot be split twice");
+        let reader = self.take_reader();
+        let writer = self.writer();
+        (writer, reader)
+    }
+
+    /// Create a writer for this signal.
+    ///
+    /// Many writers may exist for a [`Signal`]. However, for concurrent
+    /// writes, a [`SignalReader`] is only guaranteed to observe _at least_
+    /// one of the written values, not _all_ writes.
+    pub const fn writer(&self) -> SignalWriter<'_, T> {
+        SignalWriter { parent: self }
+    }
+
+    /// Try to take the reader for this signal.
+    ///
+    /// If another, non-dropped [`SignalReader`] exists for this [`Signal`],
+    /// `None` is returned.
+    pub fn try_take_reader(&self) -> Option<SignalReader<'_, T>> {
+        if self.reader_alive.swap(true, AcqRel) {
+            return None;
         }
-        (SignalWriter { parent: self }, SignalReader { parent: self })
+
+        Some(SignalReader { parent: self })
+    }
+
+    /// Take the reader for this signal.
+    ///
+    /// # Panics
+    /// This function panics if another [`SignalReader`] associated
+    /// with this `self` is alive (i.e. non-dropped).
+    pub fn take_reader(&self) -> SignalReader<'_, T> {
+        let Some(reader) = self.try_take_reader() else {
+            panic!("Cannot create duplicate reader for `Signal`");
+        };
+
+        reader
     }
 }
 
@@ -126,6 +163,12 @@ impl<T: Copy> SignalWriter<'_, T> {
 /// Facilitates the async reading of values from the Signal.
 pub struct SignalReader<'a, T: Copy> {
     parent: &'a Signal<T>,
+}
+
+impl<T: Copy> Drop for SignalReader<'_, T> {
+    fn drop(&mut self) {
+        self.parent.reader_alive.store(false, Release);
+    }
 }
 
 impl<T> core::fmt::Debug for SignalReader<'_, T>
@@ -241,12 +284,41 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn no_multi_split() {
+    fn no_simultaneous_multi_split() {
         fn scary_helper<'a>() -> (SignalWriter<'a, u32>, SignalReader<'a, u32>) {
             make_signal!(u32)
         }
         let (mut _writer1, mut _reader1) = scary_helper();
         let (mut _writer2, mut _reader2) = scary_helper();
+    }
+
+    #[test]
+    fn allow_non_simultaneous_multi_split() {
+        fn scary_helper<'a>() -> (SignalWriter<'a, u32>, SignalReader<'a, u32>) {
+            make_signal!(u32)
+        }
+
+        let (writer1, reader1) = scary_helper();
+        drop((writer1, reader1));
+
+        let (mut _writer2, mut _reader2) = scary_helper();
+    }
+
+    #[test]
+    fn disallow_simultaneous_multi_read() {
+        let signal = Signal::<()>::new();
+
+        let _reader1 = signal.try_take_reader();
+        assert!(signal.try_take_reader().is_none());
+    }
+
+    #[test]
+    fn allow_non_simultaneous_multi_read() {
+        let signal = Signal::<()>::new();
+
+        let reader1 = signal.try_take_reader().unwrap();
+        drop(reader1);
+        assert!(signal.try_take_reader().is_some());
     }
 
     #[tokio::test]

--- a/rtic-sync/src/watch.rs
+++ b/rtic-sync/src/watch.rs
@@ -38,15 +38,49 @@ impl<T: Copy> Watch<T> {
         Self(Signal::new())
     }
 
-    /// Split the watch into a writer and watch reader.
+    /// Split the watch into a writer and reader.
+    ///
+    /// # Panics
+    /// This function calls [`Self::take_reader`] and has the same
+    /// panicking behaviour.
     pub fn split(&self) -> (WatchWriter<'_, T>, WatchReader<'_, T>) {
-        if self.0.already_split.swap(true, AcqRel) {
-            panic!("`Watch` cannot be split twice");
+        let reader = self.take_reader();
+        let writer = self.writer();
+        (writer, reader)
+    }
+
+    /// Create a writer for this watch.
+    ///
+    /// Many writers may exist for a [`Watch`]. However, for concurrent
+    /// writes, a [`WatchReader`] is only guaranteed to observe _at least_
+    /// one of the writes, not _all_ writes.
+    pub const fn writer(&self) -> WatchWriter<'_, T> {
+        WatchWriter(self.0.writer())
+    }
+
+    /// Try to take the reader for this watch.
+    ///
+    /// If another, non-dropped [`WatchReader`] exists for this [`Watch`],
+    /// `None` is returned.
+    pub fn try_take_reader(&self) -> Option<WatchReader<'_, T>> {
+        if self.0.reader_alive.swap(true, AcqRel) {
+            return None;
         }
-        (
-            WatchWriter(SignalWriter { parent: &self.0 }),
-            WatchReader { parent: &self.0 },
-        )
+
+        Some(WatchReader { parent: &self.0 })
+    }
+
+    /// Take the reader for this watch.
+    ///
+    /// # Panics
+    /// This function panics if another [`WatchReader`] associated
+    /// with this `self` is alive (i.e. non-dropped).
+    pub fn take_reader(&self) -> WatchReader<'_, T> {
+        let Some(reader) = self.try_take_reader() else {
+            panic!("Cannot create duplicate reader for `Watch`");
+        };
+
+        reader
     }
 }
 
@@ -86,6 +120,12 @@ impl<T: Copy> WatchWriter<'_, T> {
 /// Facilitates the async reading of values from the Watch.
 pub struct WatchReader<'a, T: Copy> {
     parent: &'a Signal<T>,
+}
+
+impl<T: Copy> Drop for WatchReader<'_, T> {
+    fn drop(&mut self) {
+        self.parent.reader_alive.store(false, Release);
+    }
 }
 
 impl<T> core::fmt::Debug for WatchReader<'_, T>
@@ -278,12 +318,41 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn no_multi_split() {
+    fn no_simultaneous_multi_split() {
         fn scary_helper<'a>() -> (WatchWriter<'a, u32>, WatchReader<'a, u32>) {
             make_watch!(u32)
         }
         let (mut _writer1, mut _reader1) = scary_helper();
         let (mut _writer2, mut _reader2) = scary_helper();
+    }
+
+    #[test]
+    fn allow_non_simultaneous_multi_split() {
+        fn scary_helper<'a>() -> (WatchWriter<'a, u32>, WatchReader<'a, u32>) {
+            make_watch!(u32)
+        }
+
+        let (writer1, reader1) = scary_helper();
+        drop((writer1, reader1));
+
+        let (mut _writer2, mut _reader2) = scary_helper();
+    }
+
+    #[test]
+    fn disallow_simultaneous_multi_read() {
+        let watch = Watch::<()>::new();
+
+        let _reader1 = watch.try_take_reader();
+        assert!(watch.try_take_reader().is_none());
+    }
+
+    #[test]
+    fn allow_non_simultaneous_multi_read() {
+        let watch = Watch::<()>::new();
+
+        let reader1 = watch.try_take_reader().unwrap();
+        drop(reader1);
+        assert!(watch.try_take_reader().is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
In some instances, it can be very useful to have (`const`) access to the reader and writer halves of a `Watch` without being able to call `split`. Add functions to get them.

It is hard to use these functions truly correctly, but the alternative (having to create & track an `AtomicWaker` & associated state correctly instead) isn't any better.

As an example, using a `Watch` channel to detect whether an interrupt handler has been called, and doing some work on a lower priority as result of that interrupt.

```rust
static WATCH: Watch<()> = Watch::new();

fn InterruptHandler() {
    WATCH.writer().write(());
} 

// NB: only one instance of this function can be alive
// at any one time.
async fn on_interrupt() {
    let reader = WATCH.reader();
    loop {
        reader.changed().await;
    }
}
```