### PR TITLE
Remove testing features

### DIFF
--- a/book/en/src/by-example.md
+++ b/book/en/src/by-example.md
@@ -38,13 +38,13 @@ Yields this output:
 ```console
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/xtask qemu --example locals`
-INFO  xtask > Testing for platform: Lm3s6965, backend: Thumbv7
-INFO  xtask::run > 👟 Build example locals (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
+INFO  xtask::run > QEMU run for platform: Lm3s6965, backend: Thumbv7
+INFO  xtask::run > 👟 Build example locals (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
 INFO  xtask::run > ✅ Success.
-INFO  xtask::run > 👟 Run example locals in QEMU (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
+INFO  xtask::run > 👟 Run example locals in QEMU (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
 INFO  xtask::run > ✅ Success.
-INFO  xtask::results > ✅ Success: Build example locals (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
-INFO  xtask::results > ✅ Success: Run example locals in QEMU (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
+INFO  xtask::results > ✅ Success: Build example locals (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
+INFO  xtask::results > ✅ Success: Run example locals in QEMU (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
 INFO  xtask::results > 🚀🚀🚀 All tasks succeeded 🚀🚀🚀
 ```
 
@@ -52,32 +52,32 @@ It is great that examples are passing and this is part of the RTIC CI setup too,
 
 ```console
 ❯ cargo xtask qemu --verbose --example locals
-    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
-     Running `target/debug/xtask qemu --example locals --verbose`
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
+     Running `target/debug/xtask qemu --verbose --example locals`
  DEBUG xtask > Stderr of child processes is inherited: false
  DEBUG xtask > Partial features: false
- INFO  xtask > Testing for platform: Lm3s6965, backend: Thumbv7
- INFO  xtask::run > 👟 Build example locals (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
+ INFO  xtask::run > QEMU run for platform: Lm3s6965, backend: Thumbv7
+ INFO  xtask::run > 👟 Build example locals (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
  INFO  xtask::run > ✅ Success.
- INFO  xtask::run > 👟 Run example locals in QEMU (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
+ INFO  xtask::run > 👟 Run example locals in QEMU (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
  INFO  xtask::run > ✅ Success.
- INFO  xtask::results > ✅ Success: Build example locals (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
-    cd examples/lm3s6965 && cargo build --target thumbv7m-none-eabi --features test-critical-section,thumbv7-backend --release --example locals
+ INFO  xtask::results > ✅ Success: Build example locals (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
+    cd examples/lm3s6965 && cargo build --target thumbv7m-none-eabi --features thumbv7-backend --release --example locals
  DEBUG xtask::results >
-cd examples/lm3s6965 && cargo build --target thumbv7m-none-eabi --features test-critical-section,thumbv7-backend --release --example locals
+cd examples/lm3s6965 && cargo build --target thumbv7m-none-eabi --features thumbv7-backend --release --example locals
 Stderr:
-    Finished release [optimized] target(s) in 0.02s
- INFO  xtask::results > ✅ Success: Run example locals in QEMU (thumbv7m-none-eabi, release, "test-critical-section,thumbv7-backend", in examples/lm3s6965)
-    cd examples/lm3s6965 && cargo run --target thumbv7m-none-eabi --features test-critical-section,thumbv7-backend --release --example locals
+    Finished `release` profile [optimized] target(s) in 0.03s
+ INFO  xtask::results > ✅ Success: Run example locals in QEMU (thumbv7m-none-eabi, release, "thumbv7-backend", in examples/lm3s6965)
+    cd examples/lm3s6965 && cargo run --target thumbv7m-none-eabi --features thumbv7-backend --release --example locals
  DEBUG xtask::results >
-cd examples/lm3s6965 && cargo run --target thumbv7m-none-eabi --features test-critical-section,thumbv7-backend --release --example locals
+cd examples/lm3s6965 && cargo run --target thumbv7m-none-eabi --features thumbv7-backend --release --example locals
 Stdout:
 bar: local_to_bar = 1
 foo: local_to_foo = 1
 idle: local_to_idle = 1
 
 Stderr:
-    Finished release [optimized] target(s) in 0.02s
+    Finished `release` profile [optimized] target(s) in 0.03s
      Running `qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel target/thumbv7m-none-eabi/release/examples/locals`
 Timer with period zero, disabling
 

--- a/book/en/src/by-example/channel.md
+++ b/book/en/src/by-example/channel.md
@@ -44,7 +44,7 @@ async fn receiver(_c: receiver::Context, mut receiver: Receiver<'static, u32, CA
 }
 ```
 
-Channels are implemented using a small (global) _Critical Section_ (CS) for protection against race-conditions. The user must provide an CS implementation. Compiling the examples given the `--features test-critical-section` gives one possible implementation.
+Channels are implemented using a small (global) _Critical Section_ (CS) for protection against race-conditions. The user must provide an CS implementation. For the examples a CS implementation is provided by a platform crate, for example `cortex-m/critical-section-single-core` or `esp32c3/critical-section`.
 
 For a complete example:
 
@@ -53,7 +53,7 @@ For a complete example:
 ```
 
 ```console
-$ cargo xtask qemu --verbose --example async-channel --features test-critical-section
+$ cargo xtask qemu --verbose --example async-channel
 ```
 
 ```console
@@ -73,7 +73,7 @@ Looking at the output, we find that `Sender 2` will wait until the data sent by 
 > **NOTICE** _Software_ tasks at the same priority are executed asynchronously to each other, thus **NO** strict order can be assumed. (The presented order here applies only to the current implementation, and may change between RTIC framework releases.)
 
 ```console
-$ cargo xtask qemu --verbose --example async-channel-done --features test-critical-section
+$ cargo xtask qemu --verbose --example async-channel-done
 {{#include ../../../../ci/expected/lm3s6965/async-channel-done.run}}
 ```
 
@@ -86,7 +86,7 @@ In case all senders have been dropped `await`-ing on an empty receiver channel r
 ```
 
 ```console
-$ cargo xtask qemu --verbose --example async-channel-no-sender --features test-critical-section
+$ cargo xtask qemu --verbose --example async-channel-no-sender
 ```
 
 ```console
@@ -102,7 +102,7 @@ The resulting error returns the data back to the sender, allowing the sender to 
 ```
 
 ```console
-$ cargo xtask qemu --verbose --example async-channel-no-receiver --features test-critical-section
+$ cargo xtask qemu --verbose --example async-channel-no-receiver
 ```
 
 ```console
@@ -120,7 +120,7 @@ This API is exposed through `Receiver::try_recv` and `Sender::try_send`.
 ```
 
 ```console
-$ cargo xtask qemu --verbose --example async-channel-try --features test-critical-section
+$ cargo xtask qemu --verbose --example async-channel-try
 ```
 
 ```console

--- a/book/en/src/by-example/delay.md
+++ b/book/en/src/by-example/delay.md
@@ -40,7 +40,7 @@ async fn foo(_cx: foo::Context) {
 ```
 
 ```console
-$ cargo xtask qemu --verbose --example async-delay --features test-critical-section
+$ cargo xtask qemu --verbose --example async-delay
 ```
 
 ```console
@@ -96,7 +96,7 @@ For the first iteration of the loop, with `n == 0`, the `hal_get` will take 350m
 ```
 
 ```console
-$ cargo xtask qemu --verbose --example async-timeout --features test-critical-section
+$ cargo xtask qemu --verbose --example async-timeout
 ```
 
 ```console

--- a/book/en/src/monotonic_impl.md
+++ b/book/en/src/monotonic_impl.md
@@ -39,4 +39,4 @@ Contributing new implementations of `Monotonic` can be done in multiple ways:
 
 The timer queue is implemented as a list based priority queue, where list-nodes are statically allocated as part of the `Future` created when `await`-ing a Future created when waiting for the monotonic. Thus, the timer queue is infallible at run-time (its size and allocation are determined at compile time).
 
-Similarly the channels implementation, the timer-queue implementation relies on a global *Critical Section* (CS) for race protection. For the examples a CS implementation is provided by adding `--features test-critical-section` to the build options.
+Similarly the channels implementation, the timer-queue implementation relies on a global *Critical Section* (CS) for race protection. For the examples a CS implementation is provided by a platform crate, for example `cortex-m/critical-section-single-core` or `esp32c3/critical-section`.

--- a/examples/esp32c3/Cargo.lock
+++ b/examples/esp32c3/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "esp-hal",
  "esp-println",
  "esp32c3 0.31.0",
+ "portable-atomic",
  "rtic",
  "rtic-monotonics",
 ]

--- a/examples/esp32c3/Cargo.toml
+++ b/examples/esp32c3/Cargo.toml
@@ -7,8 +7,7 @@ license = "MIT OR Apache-2.0"
 [workspace]
 
 [features]
-test-critical-section = []
-riscv-esp32c3-backend = ["rtic/riscv-esp32c3-backend", "rtic-monotonics/esp32c3-systimer"]
+riscv-esp32c3-backend = ["rtic/riscv-esp32c3-backend", "rtic-monotonics/esp32c3-systimer", "portable-atomic/unsafe-assume-single-core"]
 
 [dependencies]
 esp-backtrace = { version = "0.17.0", features = [
@@ -23,3 +22,4 @@ esp-println = { version = "0.15.0", features = ["esp32c3"] }
 esp32c3 = { version = "0.31.0", features = ["critical-section"] }
 rtic = { path = "../../rtic/" }
 rtic-monotonics = { path = "../../rtic-monotonics/" }
+portable-atomic = "1.13"

--- a/examples/esp32c6/Cargo.toml
+++ b/examples/esp32c6/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 [workspace]
 
 [features]
-test-critical-section = []
 riscv-esp32c6-backend = ["rtic/riscv-esp32c6-backend", "rtic-monotonics/esp32c6-systimer"]
 
 [dependencies]

--- a/examples/hifive1/Cargo.toml
+++ b/examples/hifive1/Cargo.toml
@@ -20,4 +20,3 @@ portable-atomic = { version = "1", features = ["unsafe-assume-single-core", "for
 [features]
 riscv-clint-backend = ["rtic/riscv-clint-backend"]
 riscv-mecall-backend = ["rtic/riscv-mecall-backend"]
-test-critical-section = []

--- a/examples/lm3s6965/Cargo.lock
+++ b/examples/lm3s6965/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -299,9 +299,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "lm3s6965"
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nb"
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -527,6 +527,7 @@ dependencies = [
  "heapless 0.8.0",
  "lm3s6965",
  "panic-semihosting",
+ "portable-atomic",
  "rtic",
  "rtic-common",
  "rtic-monotonics",
@@ -545,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scoped-tls"
@@ -587,9 +588,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -610,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]

--- a/examples/lm3s6965/Cargo.toml
+++ b/examples/lm3s6965/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 heapless = "0.8"
 lm3s6965 = "0.2"
-cortex-m = "0.7.0"
+cortex-m = { version = "0.7.0", features = ["critical-section-single-core"] }
 cortex-m-semihosting = "0.5.0"
 rtic-time = { path = "../../rtic-time" }
 rtic-sync = { path = "../../rtic-sync" }
@@ -19,6 +19,7 @@ rtic-common = { path = "../../rtic-common" }
 rtic-monotonics = { path = "../../rtic-monotonics", features = ["cortex-m-systick"] }
 rtic = { path = "../../rtic" }
 cfg-if = "1.0"
+portable-atomic = "1.13"
 
 [dependencies.futures]
 version = "0.3.26"
@@ -30,11 +31,7 @@ features = ["exit"]
 version = "0.6.0"
 
 [features]
-test-critical-section = [
-  "rtic/test-critical-section",
-  "cortex-m/critical-section-single-core",
-]
-thumbv6-backend = ["rtic/thumbv6-backend"]
+thumbv6-backend = ["rtic/thumbv6-backend", "portable-atomic/critical-section"]
 thumbv7-backend = ["rtic/thumbv7-backend"]
 thumbv8base-backend = ["rtic/thumbv8base-backend"]
 thumbv8main-backend = ["rtic/thumbv8main-backend"]

--- a/rtic-common/CHANGELOG.md
+++ b/rtic-common/CHANGELOG.md
@@ -11,6 +11,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+- Removed `testing` feature
+
 ### Fixed
 
 ## v1.1.0 - 2025-06-22

--- a/rtic-common/Cargo.toml
+++ b/rtic-common/Cargo.toml
@@ -21,6 +21,8 @@ repository = "https://github.com/rtic-rs/rtic"
 critical-section = "1"
 portable-atomic = { version = "1", default-features = false }
 
+[dev-dependencies]
+critical-section = { version = "1", features = [ "std" ] }
+
 [features]
 default = []
-testing = ["critical-section/std"]

--- a/rtic-sync/CHANGELOG.md
+++ b/rtic-sync/CHANGELOG.md
@@ -18,6 +18,10 @@ For each category, _Added_, _Changed_, _Fixed_ add new entries at the top!
 
 - One can now obtain `Reader`s and `Writer`s for a `Watch` and `Signal` individually (i.e. without calling `split()`), and if a `Reader` is dropped it may be recreated.
 
+### Changed
+
+- Removed `testing` feature
+
 ## v1.5.0 - 2026-05-30
 
 ### Added

--- a/rtic-sync/Cargo.toml
+++ b/rtic-sync/Cargo.toml
@@ -33,10 +33,10 @@ static_cell = "2.1.0"
 
 [target.'cfg(not(loom))'.dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time"], default-features = false }
+critical-section = { version = "1", features = [ "std" ] }
 
 [features]
 default = []
-testing = ["critical-section/std", "rtic-common/testing"]
 defmt-03 = ["dep:defmt-03", "embedded-hal/defmt-03", "embedded-hal-async/defmt-03", "embedded-hal-bus/defmt-03"]
 
 [lints.rust]

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -23,6 +23,7 @@ Example:
 ### Changed
 
 - Removed `cortex-m`, `esp32c3`, `esp32c6`, `riscv`, and `riscv-slic` features. These were all implicit features from dependencies that should only be activated by selecting a backend.
+- Removed `test-critical-section` feature
 
 ## [v2.3.0] - 2026-07-08
 

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -74,6 +74,3 @@ riscv-mecall-backend = [
   "riscv-slic/mecall-backend",
   "rtic-macros/riscv-mecall",
 ]
-
-# needed for testing
-test-critical-section = ["portable-atomic/critical-section"]

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -51,14 +51,9 @@ impl Package {
     /// Without package specified the features for RTIC are required
     /// With only a single package which is not RTIC, no special
     /// features are needed
-    pub fn features(
-        &self,
-        target: Target,
-        backend: Backends,
-        partial: bool,
-    ) -> Vec<Option<String>> {
+    pub fn features(&self, backend: Backends, partial: bool) -> Vec<Option<String>> {
         match self {
-            Package::Rtic => vec![Some(target.and_features(backend.to_rtic_feature()))],
+            Package::Rtic => vec![Some(backend.to_rtic_features().to_string())],
             Package::RticMacros => {
                 vec![Some(backend.to_rtic_macros_feature().to_string())]
             }
@@ -96,7 +91,7 @@ impl TestMetadata {
     pub fn match_package(package: Package, backend: Backends, loom: bool) -> CargoCommand<'static> {
         match package {
             Package::Rtic => {
-                let features = Some(backend.to_target().and_features(backend.to_rtic_feature()));
+                let features = Some(backend.to_rtic_features().to_string());
                 CargoCommand::Test {
                     package: Some(package.name()),
                     features,
@@ -114,14 +109,14 @@ impl TestMetadata {
             },
             Package::RticSync => CargoCommand::Test {
                 package: Some(package.name()),
-                features: Some("testing".to_owned()),
+                features: None,
                 test: None,
                 deny_warnings: true,
                 loom,
             },
             Package::RticCommon => CargoCommand::Test {
                 package: Some(package.name()),
-                features: Some("testing".to_owned()),
+                features: None,
                 test: None,
                 deny_warnings: true,
                 loom,
@@ -177,16 +172,24 @@ impl Backends {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_rtic_feature(&self) -> &'static str {
+    /// Get the RTIC features required to build `rtic` for
+    /// this backend.
+    pub fn to_rtic_features(&self) -> &'static str {
         match self {
-            Backends::Thumbv6 => "thumbv6-backend",
+            Backends::Thumbv6 => "thumbv6-backend,portable-atomic/critical-section",
             Backends::Thumbv7 => "thumbv7-backend",
             Backends::Thumbv8Base => "thumbv8base-backend",
             Backends::Thumbv8Main => "thumbv8main-backend",
-            Backends::RiscvEsp32C3 => "riscv-esp32c3-backend",
+            Backends::RiscvEsp32C3 => {
+                "riscv-esp32c3-backend,portable-atomic/unsafe-assume-single-core"
+            }
             Backends::RiscvEsp32C6 => "riscv-esp32c6-backend",
-            Backends::Riscv32ImcClint | Backends::Riscv32ImacClint => "riscv-clint-backend",
-            Backends::Riscv32ImcMecall | Backends::Riscv32ImacMecall => "riscv-mecall-backend",
+            Backends::Riscv32ImcClint | Backends::Riscv32ImacClint => {
+                "riscv-clint-backend,portable-atomic/unsafe-assume-single-core"
+            }
+            Backends::Riscv32ImcMecall | Backends::Riscv32ImacMecall => {
+                "riscv-mecall-backend,portable-atomic/unsafe-assume-single-core"
+            }
         }
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,8 +23,6 @@ pub struct Target<'a> {
 }
 
 impl<'a> Target<'a> {
-    const DEFAULT_FEATURES: &'static str = "test-critical-section";
-
     pub const fn new(triple: &'a str, has_std: bool) -> Self {
         Self { triple, has_std }
     }
@@ -35,10 +33,6 @@ impl<'a> Target<'a> {
 
     pub fn has_std(&self) -> bool {
         self.has_std
-    }
-
-    pub fn and_features(&self, features: &str) -> String {
-        format!("{},{}", Self::DEFAULT_FEATURES, features)
     }
 }
 

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -176,7 +176,7 @@ pub fn cargo<'c>(
         .packages()
         .flat_map(|package| {
             let target = backend.to_target();
-            let features = package.features(target, backend, globals.partial);
+            let features = package.features(backend, globals.partial);
             into_iter(features).map(move |f| (package, target, f))
         })
         .map(move |(package, target, features)| {
@@ -224,7 +224,7 @@ pub fn cargo_example<'c>(
     let runner = into_iter(examples).map(|example| {
         let path = format!("examples/{}", platform.name());
         let dir = Some(PathBuf::from(path));
-        let features = Some(backend.to_target().and_features(backend.to_rtic_feature()));
+        let features = Some(backend.to_rtic_features().to_string());
         let mode = BuildMode::Release;
 
         let command = match operation {
@@ -266,7 +266,7 @@ pub fn cargo_clippy<'c>(
         .packages()
         .flat_map(|package| {
             let target = backend.to_target();
-            let features = package.features(target, backend, globals.partial);
+            let features = package.features(backend, globals.partial);
             into_iter(features).map(move |f| (package, target, f))
         })
         .map(move |(package, target, features)| {
@@ -329,7 +329,7 @@ pub fn cargo_doc<'c>(
 
     let features = Some(format!(
         "{},{}",
-        backend.to_target().and_features(backend.to_rtic_feature()),
+        backend.to_rtic_features(),
         extra_doc_features.join(",")
     ));
 
@@ -392,7 +392,7 @@ pub fn qemu_run_examples<'c>(
 ) -> Vec<FinalRunResult<'c>> {
     info!("QEMU run for platform: {platform:?}, backend: {backend:?}");
     let target = backend.to_target();
-    let features = Some(target.and_features(backend.to_rtic_feature()));
+    let features = Some(backend.to_rtic_features().to_string());
 
     into_iter(examples)
         .flat_map(|example| {
@@ -441,7 +441,7 @@ pub fn build_and_check_size<'c>(
 ) -> Vec<FinalRunResult<'c>> {
     info!("Measuring for platform: {platform:?}, backend: {backend:?}");
     let target = backend.to_target();
-    let features = Some(target.and_features(backend.to_rtic_feature()));
+    let features = Some(backend.to_rtic_features().to_string());
 
     let runner = into_iter(examples)
         .flat_map(|example| {


### PR DESCRIPTION
There were a bunch of testing features that really don't add anything: migrate them to `dev-dependencies`, or just turn them on by default.

Once more a technically breaking change: removing a feature from `rtic` (even though it was never intended to be used)