### PR TITLE
xtask: don't try to set rust flags for examples

### DIFF
--- a/examples/esp32c3/.cargo/config.toml
+++ b/examples/esp32c3/.cargo/config.toml
@@ -10,8 +10,6 @@ rustflags = [
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",
-  # This should be last.
-  "-C", "link-arg=-Tlinkall.x",
 ]
 
 target = "riscv32imc-unknown-none-elf"

--- a/examples/esp32c3/build.rs
+++ b/examples/esp32c3/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-link-arg=-Tlinkall.x");
+}

--- a/examples/esp32c6/.cargo/config.toml
+++ b/examples/esp32c6/.cargo/config.toml
@@ -6,8 +6,6 @@ rustflags = [
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",
-  # This should be last.
-  "-C", "link-arg=-Tlinkall.x",
 ]
 
 target = "riscv32imac-unknown-none-elf"

--- a/examples/esp32c6/build.rs
+++ b/examples/esp32c6/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-link-arg=-Tlinkall.x");
+}

--- a/examples/hifive1/.cargo/config.toml
+++ b/examples/hifive1/.cargo/config.toml
@@ -2,7 +2,6 @@
 runner = "qemu-system-riscv32 -machine sifive_e,revb=true -nographic -semihosting-config enable=on,target=native -kernel"
 # runner = "riscv64-unknown-elf-gdb -q -x gdb_init"
 rustflags = [
-  "-C", "link-arg=-Thifive1-link.x",
   "--cfg", "portable_atomic_target_feature=\"zaamo\"",
 ]
 

--- a/examples/hifive1/build.rs
+++ b/examples/hifive1/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-link-arg=-Thifive1-link.x");
+}

--- a/examples/lm3s6965/.cargo/config.toml
+++ b/examples/lm3s6965/.cargo/config.toml
@@ -4,10 +4,5 @@ runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semiho
 [target.thumbv7m-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
 
-[target.'cfg(all(target_arch = "arm", target_os = "none"))']
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-]
-
 [build]
 target = "thumbv7m-none-eabi"

--- a/examples/lm3s6965/build.rs
+++ b/examples/lm3s6965/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-link-arg=-Tlink.x");
+}

--- a/examples/nrf52840_blinky/.cargo/config.toml
+++ b/examples/nrf52840_blinky/.cargo/config.toml
@@ -1,15 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-rs run --chip nRF52840_xxAA"
 
-rustflags = [
-  "-C", "linker=flip-link",
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
-  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
-  "-C", "link-arg=--nmagic",
-]
-
 [build]
 target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 

--- a/examples/nrf52840_blinky/build.rs
+++ b/examples/nrf52840_blinky/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo::rustc-link-arg=-Tlink.x");
+    println!("cargo::rustc-link-arg=-Tdefmt.x");
+    println!("cargo::rustc-link-arg=--nmagic");
+}

--- a/examples/rp2040_local_i2c_init/.cargo/config.toml
+++ b/examples/rp2040_local_i2c_init/.cargo/config.toml
@@ -9,26 +9,6 @@
 # runner = "gdb-multiarch -q -x openocd.gdb"
 # runner = "gdb -q -x openocd.gdb"
 
-rustflags = [
-  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
-  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
-  "-C", "link-arg=--nmagic",
-
-  # LLD (shipped with the Rust toolchain) is used as the default linker
-  "-C", "link-arg=-Tlink.x",
-
-  # if you run into problems with LLD switch to the GNU linker by commenting out
-  # this line
-  # "-C", "linker=arm-none-eabi-ld",
-
-  # if you need to link to pre-compiled C libraries provided by a C toolchain
-  # use GCC as the linker by commenting out both lines above and then
-  # uncommenting the three lines below
-  # "-C", "linker=arm-none-eabi-gcc",
-  # "-C", "link-arg=-Wl,-Tlink.x",
-  # "-C", "link-arg=-nostartfiles",
-]
-
 [build]
 # Pick ONE of these compilation targets
 target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+

--- a/examples/rp2040_local_i2c_init/build.rs
+++ b/examples/rp2040_local_i2c_init/build.rs
@@ -28,4 +28,7 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg=--nmagic");
+    println!("cargo:rustc-link-arg=-Tlink.x");
 }

--- a/examples/stm32f1_bluepill_blinky/.cargo/config.toml
+++ b/examples/stm32f1_bluepill_blinky/.cargo/config.toml
@@ -9,26 +9,6 @@
 # runner = "gdb-multiarch -q -x openocd.gdb"
 # runner = "gdb -q -x openocd.gdb"
 
-rustflags = [
-  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
-  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
-  "-C", "link-arg=--nmagic",
-
-  # LLD (shipped with the Rust toolchain) is used as the default linker
-  "-C", "link-arg=-Tlink.x",
-
-  # if you run into problems with LLD switch to the GNU linker by commenting out
-  # this line
-  # "-C", "linker=arm-none-eabi-ld",
-
-  # if you need to link to pre-compiled C libraries provided by a C toolchain
-  # use GCC as the linker by commenting out both lines above and then
-  # uncommenting the three lines below
-  # "-C", "linker=arm-none-eabi-gcc",
-  # "-C", "link-arg=-Wl,-Tlink.x",
-  # "-C", "link-arg=-nostartfiles",
-]
-
 [build]
 # Pick ONE of these compilation targets
 # target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+

--- a/examples/stm32f1_bluepill_blinky/build.rs
+++ b/examples/stm32f1_bluepill_blinky/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-arg=--nmagic");
+    println!("cargo:rustc-link-arg=-Tlink.x");
+}

--- a/examples/stm32f3_blinky/.cargo/config.toml
+++ b/examples/stm32f3_blinky/.cargo/config.toml
@@ -9,26 +9,6 @@
 # runner = "gdb-multiarch -q -x openocd.gdb"
 # runner = "gdb -q -x openocd.gdb"
 
-rustflags = [
-  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
-  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
-  "-C", "link-arg=--nmagic",
-
-  # LLD (shipped with the Rust toolchain) is used as the default linker
-  "-C", "link-arg=-Tlink.x",
-
-  # if you run into problems with LLD switch to the GNU linker by commenting out
-  # this line
-  # "-C", "linker=arm-none-eabi-ld",
-
-  # if you need to link to pre-compiled C libraries provided by a C toolchain
-  # use GCC as the linker by commenting out both lines above and then
-  # uncommenting the three lines below
-  # "-C", "linker=arm-none-eabi-gcc",
-  # "-C", "link-arg=-Wl,-Tlink.x",
-  # "-C", "link-arg=-nostartfiles",
-]
-
 [build]
 # Pick ONE of these compilation targets
 # target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+

--- a/examples/stm32f3_blinky/build.rs
+++ b/examples/stm32f3_blinky/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-arg=--nmagic");
+    println!("cargo:rustc-link-arg=-Tlink.x");
+}

--- a/examples/stm32f411_adc/.cargo/config.toml
+++ b/examples/stm32f411_adc/.cargo/config.toml
@@ -1,11 +1,5 @@
 [target.thumbv7em-none-eabihf]
-
 runner = "probe-rs run --chip STM32F411CEUx"
-
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f411_adc/build.rs
+++ b/examples/stm32f411_adc/build.rs
@@ -28,4 +28,7 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg=--nmagic");
+    println!("cargo:rustc-link-arg=-Tlink.x");
 }

--- a/examples/stm32f411_adc_and_mpsc_channel/.cargo/config.toml
+++ b/examples/stm32f411_adc_and_mpsc_channel/.cargo/config.toml
@@ -1,11 +1,5 @@
 [target.thumbv7em-none-eabihf]
-
 runner = "probe-rs run --chip STM32F411CEUx"
-
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f411_adc_and_mpsc_channel/build.rs
+++ b/examples/stm32f411_adc_and_mpsc_channel/build.rs
@@ -28,4 +28,7 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg=--nmagic");
+    println!("cargo:rustc-link-arg=-Tlink.x");
 }

--- a/examples/stm32f411_encoder_polling/.cargo/config.toml
+++ b/examples/stm32f411_encoder_polling/.cargo/config.toml
@@ -1,11 +1,5 @@
 [target.thumbv7em-none-eabihf]
-
 runner = "probe-rs run --chip STM32F411CEUx"
-
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f411_encoder_polling/build.rs
+++ b/examples/stm32f411_encoder_polling/build.rs
@@ -28,4 +28,7 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg=-Tlink.x");
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 }

--- a/examples/stm32f411_pwm_generation_and_dwt/.cargo/config.toml
+++ b/examples/stm32f411_pwm_generation_and_dwt/.cargo/config.toml
@@ -1,11 +1,5 @@
 [target.thumbv7em-none-eabihf]
-
 runner = "probe-rs run --chip STM32F411CEUx"
-
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f411_pwm_generation_and_dwt/build.rs
+++ b/examples/stm32f411_pwm_generation_and_dwt/build.rs
@@ -28,4 +28,7 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg=-Tlink.x");
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 }

--- a/examples/stm32f411_rtc_interrupt/.cargo/config.toml
+++ b/examples/stm32f411_rtc_interrupt/.cargo/config.toml
@@ -1,11 +1,5 @@
 [target.thumbv7em-none-eabihf]
-
 runner = "probe-rs run --chip STM32F411CEUx"
-
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f411_rtc_interrupt/build.rs
+++ b/examples/stm32f411_rtc_interrupt/build.rs
@@ -28,4 +28,7 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg=-Tlink.x");
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 }

--- a/examples/stm32g030f6_periodic_prints/.cargo/config.toml
+++ b/examples/stm32g030f6_periodic_prints/.cargo/config.toml
@@ -1,14 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # TODO(2) replace `$CHIP` with your chip's name (see `probe-run --list-chips` output)
 runner = "probe-rs run --chip STM32G030F6Px"
-rustflags = [
-  "-C", "linker=flip-link",
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
-  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
-  "-C", "link-arg=--nmagic",
-]
 
 [build]
 # TODO(3) Adjust the compilation target.

--- a/examples/stm32g030f6_periodic_prints/build.rs
+++ b/examples/stm32g030f6_periodic_prints/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tlink.x");
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+    println!("cargo:rustc-linker=--nmagic");
+}

--- a/examples/teensy4_blinky/.cargo/config.toml
+++ b/examples/teensy4_blinky/.cargo/config.toml
@@ -1,6 +1,5 @@
 [target.thumbv7em-none-eabihf]
 runner = "python3 run.py"
-rustflags = ["-C", "link-arg=-Tt4link.x"]
 
 [build]
 target = "thumbv7em-none-eabihf" # Teensy 4

--- a/examples/teensy4_blinky/build.rs
+++ b/examples/teensy4_blinky/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-link-arg=-Tt4link.x");
+}

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -293,7 +293,7 @@ impl Platforms {
     pub fn rust_flags(&self) -> Vec<String> {
         let c = "-C".to_string();
         match self {
-            Platforms::Esp32C3 | Platforms::Esp32C6 => vec![c, "link-arg=-Tlinkall.x".to_string()],
+            Platforms::Esp32C3 | Platforms::Esp32C6 => Vec::new(),
             Platforms::Hifive1 => vec![c, "link-arg=-Thifive1-link.x".to_string()],
             Platforms::Lm3s6965 => vec![c, "link-arg=-Tlink.x".to_string()],
             Platforms::Nrf52840 => vec![

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -295,7 +295,7 @@ impl Platforms {
         match self {
             Platforms::Esp32C3 | Platforms::Esp32C6 => Vec::new(),
             Platforms::Hifive1 => Vec::new(),
-            Platforms::Lm3s6965 => vec![c, "link-arg=-Tlink.x".to_string()],
+            Platforms::Lm3s6965 => Vec::new(),
             Platforms::Nrf52840 => vec![
                 c.clone(),
                 "linker=flip-link".to_string(),

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -294,7 +294,7 @@ impl Platforms {
         let c = "-C".to_string();
         match self {
             Platforms::Esp32C3 | Platforms::Esp32C6 => Vec::new(),
-            Platforms::Hifive1 => vec![c, "link-arg=-Thifive1-link.x".to_string()],
+            Platforms::Hifive1 => Vec::new(),
             Platforms::Lm3s6965 => vec![c, "link-arg=-Tlink.x".to_string()],
             Platforms::Nrf52840 => vec![
                 c.clone(),

--- a/xtask/src/argument_parsing.rs
+++ b/xtask/src/argument_parsing.rs
@@ -289,45 +289,6 @@ impl Platforms {
         name.to_string()
     }
 
-    /// Rust flags needed for the platform when building
-    pub fn rust_flags(&self) -> Vec<String> {
-        let c = "-C".to_string();
-        match self {
-            Platforms::Esp32C3 | Platforms::Esp32C6 => Vec::new(),
-            Platforms::Hifive1 => Vec::new(),
-            Platforms::Lm3s6965 => Vec::new(),
-            Platforms::Nrf52840 => vec![
-                c.clone(),
-                "linker=flip-link".to_string(),
-                c.clone(),
-                "link-arg=-Tlink.x".to_string(),
-                c.clone(),
-                "link-arg=-Tdefmt.x".to_string(),
-                c,
-                "link-arg=--nmagic".to_string(),
-            ],
-            Platforms::Rp2040 => vec![
-                c.clone(),
-                "link-arg=--nmagic".to_string(),
-                c,
-                "link-arg=-Tlink.x".to_string(),
-            ],
-            Platforms::Stm32f3 => vec![
-                c.clone(),
-                "link-arg=--nmagic".to_string(),
-                c,
-                "link-arg=-Tlink.x".to_string(),
-            ],
-            Platforms::Stm32f411 => vec![
-                c.clone(),
-                "link-arg=-Tlink.x".to_string(),
-                c,
-                "link-arg=-Tdefmt.x".to_string(),
-            ],
-            Platforms::Teensy4 => vec![c, "link-arg=-Tt4link.x".to_string()],
-        }
-    }
-
     /// Get the default backend for the platform
     pub fn default_backend(&self) -> Backends {
         match self {

--- a/xtask/src/cargo_command.rs
+++ b/xtask/src/cargo_command.rs
@@ -34,7 +34,6 @@ pub enum CargoCommand<'a> {
     },
     ExampleBuild {
         cargoarg: &'a Option<&'a str>,
-        platform: Platforms, // to tell which platform. If None, it assumes lm3s6965
         example: &'a str,
         target: Option<Target<'a>>,
         features: Option<String>,
@@ -217,7 +216,6 @@ impl core::fmt::Display for CargoCommand<'_> {
             }
             CargoCommand::ExampleBuild {
                 cargoarg,
-                platform: _,
                 example,
                 target,
                 features,
@@ -628,7 +626,6 @@ impl<'a> CargoCommand<'a> {
             }
             CargoCommand::ExampleBuild {
                 cargoarg,
-                platform: _,
                 example,
                 features,
                 mode,
@@ -721,27 +718,11 @@ impl<'a> CargoCommand<'a> {
             CargoCommand::Clippy { .. } => None,
             CargoCommand::Doc { .. } => Some(("RUSTDOCFLAGS", "-D warnings".to_string())),
 
-            CargoCommand::Qemu {
-                platform,
-                deny_warnings,
-                ..
-            }
-            | CargoCommand::ExampleBuild {
-                platform,
-                deny_warnings,
-                ..
-            }
-            | CargoCommand::ExampleSize {
-                platform,
-                deny_warnings,
-                ..
-            } => {
+            CargoCommand::Qemu { deny_warnings, .. }
+            | CargoCommand::ExampleBuild { deny_warnings, .. }
+            | CargoCommand::ExampleSize { deny_warnings, .. } => {
                 if *deny_warnings {
-                    let rust_flags = platform.rust_flags().join(" ");
-                    let rust_flags = format!("-D warnings {}", rust_flags);
-                    // NOTE: this also needs the link-arg because .cargo/config.toml
-                    // is ignored if you set the RUSTFLAGS env variable.
-                    Some(("RUSTFLAGS", rust_flags))
+                    Some(("RUSTFLAGS", "-D warnings".to_string()))
                 // TODO make this configurable
                 } else {
                     None

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -240,7 +240,6 @@ pub fn cargo_example<'c>(
             },
             BuildOrCheck::Build => CargoCommand::ExampleBuild {
                 cargoarg,
-                platform,
                 example,
                 target: Some(backend.to_target()),
                 features,
@@ -403,7 +402,6 @@ pub fn qemu_run_examples<'c>(
 
             let cmd_build = CargoCommand::ExampleBuild {
                 cargoarg: &None,
-                platform,
                 example,
                 target,
                 features: features.clone(),
@@ -453,7 +451,6 @@ pub fn build_and_check_size<'c>(
             // Make sure the requested example(s) are built
             let cmd_build = CargoCommand::ExampleBuild {
                 cargoarg: &Some("--quiet"),
-                platform,
                 example,
                 target,
                 features: features.clone(),


### PR DESCRIPTION
I don't know how this became such a mess, but important details are splling left right and center. I'm going to publish a bunch of changes (hopefully a stack!) that tries to fix `xtask` so that it becomes less of a "must know it all" builder.

There is now (and there has been, for a while) a better way to set linker stuff. `xtask` should not have to care about it, so remove it all and move it into build scripts.

The only thing that actually changes it that some examples are now no longer linked with `flip-link`, which is a non-problem IMO.