### PR TITLE
ci: fix audit.yaml

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -14,4 +14,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # RUSTSEC-2024-0436: Paste (which is mature/stable) only pulled in by examples/
           # dependencies such as esp-hal, riscv, rp2040-hal, stm32f3xx-hal etc.
-          ignore: ["RUSTSEC-2024-0436"]
+          ignore: "RUSTSEC-2024-0436"


### PR DESCRIPTION
The current `audit.yaml` doesn't work: the `ignore` line should be "Comma-separated list of advisory ids to ignore" (I don't know why they chose this: it seems illogical, but it is what it is :shrug: )

See the new and improved [succesful run](https://github.com/rtic-rs/rtic/actions/runs/30393807076)