### PR TITLE
Fix bugs in local tasks

### DIFF
--- a/examples/lm3s6965/examples/spawn_local.rs
+++ b/examples/lm3s6965/examples/spawn_local.rs
@@ -30,7 +30,7 @@ mod app {
         cx.local_spawner.task2(Default::default()).unwrap();
     }
 
-    #[task(priority = 1, local_task = true)]
+    #[task(local_task = true, priority = 1)]
     async fn task2(_cx: task2::Context, _nsns: NotSendNotSync) {
         hprintln!("Hello from task2!");
         debug::exit(debug::EXIT_SUCCESS); // Exit QEMU simulator

--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -12,6 +12,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - Add missing docs to `LocalSpawner` struct
 - Removed explicit `riscv-slic` feature (this was only used to activate functionality shared between `riscv-clint` and `riscv-mecall`).
 - Selecting no or more than one implementation now fails in the build script instead of during compilation.
+- `local_task` arguments can be patterns instead of just an ident.
+- The `local_task = true` argument to `#[task]` must no longer be the last argument.
 
 ## [v2.3.0] - 2026-07-08
 

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -216,16 +216,15 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
                     } else {
                         quote!(<'a>)
                     };
-                    let input_vals = inputs.iter().map(|i| &i.pat).collect::<Vec<_>>();
-                    let (_input_args, _input_tupled, _input_untupled, input_ty) = util::regroup_inputs(&task.inputs);
+                    let (input_args, _input_tupled, input_untupled, input_ty) = util::regroup_inputs(inputs);
                     quote! {
                         #(#attrs)*
                         #(#cfgs)*
                         #[allow(non_snake_case)]
-                        pub(super) fn #ident #generics(&self #(,#inputs)*) -> ::core::result::Result<(), #input_ty> {
+                        pub(super) fn #ident #generics(&self #(,#input_args)*) -> ::core::result::Result<(), #input_ty> {
                             // SAFETY: This is safe to call since this can only be called
                             // from the same executor
-                            unsafe { #internal_spawn_ident(#(#input_vals,)*) }
+                            unsafe { #internal_spawn_ident(#(#input_untupled,)*) }
                         }
                     }
                 })

--- a/rtic-macros/src/syntax/parse.rs
+++ b/rtic-macros/src/syntax/parse.rs
@@ -208,10 +208,6 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
             let ident: Ident = input.parse()?;
             let ident_s = ident.to_string();
 
-            // Handle equal sign
-            let eq = input.parse::<Token![=]>();
-
-            // Only local_task supports omitting the value
             if &*ident_s == "local_task" {
                 if local_task.is_some() {
                     return Err(parse::Error::new(
@@ -220,88 +216,89 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
                     ));
                 }
 
-                if eq.is_ok() {
+                // The equal sign and value after it is optional.
+                if input.parse::<Token![=]>().is_ok() {
                     let lit: LitBool = input.parse()?;
                     local_task = Some(lit.value);
                 } else {
                     local_task = Some(true); // Default to true
                 }
-                break;
             } else {
-                eq?
+                // The equal sign is mandatory.
+                input.parse::<Token![=]>()?;
+
+                match &*ident_s {
+                    "binds" => {
+                        if binds.is_some() {
+                            return Err(parse::Error::new(
+                                ident.span(),
+                                "argument appears more than once",
+                            ));
+                        }
+
+                        // Parse identifier name
+                        let ident = input.parse()?;
+
+                        binds = Some(ident);
+                    }
+
+                    "priority" => {
+                        if priority.is_some() {
+                            return Err(parse::Error::new(
+                                ident.span(),
+                                "argument appears more than once",
+                            ));
+                        }
+
+                        // #lit
+                        let lit: LitInt = input.parse()?;
+
+                        if !lit.suffix().is_empty() {
+                            return Err(parse::Error::new(
+                                lit.span(),
+                                "this literal must be unsuffixed",
+                            ));
+                        }
+
+                        let value = lit.base10_parse::<u8>().ok();
+                        if value.is_none() {
+                            return Err(parse::Error::new(
+                                lit.span(),
+                                "this literal must be in the range 0...255",
+                            ));
+                        }
+
+                        prio_span = Some(lit.span());
+                        priority = Some(value.unwrap());
+                    }
+
+                    "shared" => {
+                        if shared_resources.is_some() {
+                            return Err(parse::Error::new(
+                                ident.span(),
+                                "argument appears more than once",
+                            ));
+                        }
+
+                        shared_resources = Some(util::parse_shared_resources(input)?);
+                    }
+
+                    "local" => {
+                        if local_resources.is_some() {
+                            return Err(parse::Error::new(
+                                ident.span(),
+                                "argument appears more than once",
+                            ));
+                        }
+
+                        local_resources = Some(util::parse_local_resources(input)?);
+                    }
+
+                    _ => {
+                        return Err(parse::Error::new(ident.span(), "unexpected argument"));
+                    }
+                }
             };
-
-            match &*ident_s {
-                "binds" => {
-                    if binds.is_some() {
-                        return Err(parse::Error::new(
-                            ident.span(),
-                            "argument appears more than once",
-                        ));
-                    }
-
-                    // Parse identifier name
-                    let ident = input.parse()?;
-
-                    binds = Some(ident);
-                }
-
-                "priority" => {
-                    if priority.is_some() {
-                        return Err(parse::Error::new(
-                            ident.span(),
-                            "argument appears more than once",
-                        ));
-                    }
-
-                    // #lit
-                    let lit: LitInt = input.parse()?;
-
-                    if !lit.suffix().is_empty() {
-                        return Err(parse::Error::new(
-                            lit.span(),
-                            "this literal must be unsuffixed",
-                        ));
-                    }
-
-                    let value = lit.base10_parse::<u8>().ok();
-                    if value.is_none() {
-                        return Err(parse::Error::new(
-                            lit.span(),
-                            "this literal must be in the range 0...255",
-                        ));
-                    }
-
-                    prio_span = Some(lit.span());
-                    priority = Some(value.unwrap());
-                }
-
-                "shared" => {
-                    if shared_resources.is_some() {
-                        return Err(parse::Error::new(
-                            ident.span(),
-                            "argument appears more than once",
-                        ));
-                    }
-
-                    shared_resources = Some(util::parse_shared_resources(input)?);
-                }
-
-                "local" => {
-                    if local_resources.is_some() {
-                        return Err(parse::Error::new(
-                            ident.span(),
-                            "argument appears more than once",
-                        ));
-                    }
-
-                    local_resources = Some(util::parse_local_resources(input)?);
-                }
-
-                _ => {
-                    return Err(parse::Error::new(ident.span(), "unexpected argument"));
-                }
-            }
 
             if input.is_empty() {
                 break;
@@ -310,6 +307,7 @@ fn task_args(tokens: TokenStream2) -> parse::Result<Either<HardwareTaskArgs, Sof
             // Handle comma: ,
             let _: Token![,] = input.parse()?;
         }
+
         let shared_resources = shared_resources.unwrap_or_default();
         let local_resources = local_resources.unwrap_or_default();
         let local_task = local_task.unwrap_or(false);


### PR DESCRIPTION
Fix two bugs in local tasks:

1. `local_task` was forced to be the last argument to the `#[task]`
2. `local_task` arguments cannot "be fancy" (i.e. be anything other than a plain `ident`)

For #2 I have no clue if I'm doing it right: it's a bit hard to figure out what `regroup_inputs` is supposed to do, but I've basically copied what the non-`local_task` spawn does and it appears to work.

If merged, fixes #1222 