### PR TITLE
ci: work around bug in cortex-m

### DIFF
--- a/rtic/build.rs
+++ b/rtic/build.rs
@@ -13,6 +13,16 @@ fn main() {
     // Get the backend feature selected by the user
     let mut backends: Vec<_> = backends().collect();
 
+    // Temporary workaround for https://github.com/rust-embedded/cortex-m/issues/680
+    let target = env::var("TARGET").unwrap();
+    let host_triple = env::var("HOST").unwrap();
+
+    println!("cargo::rustc-check-cfg=cfg(native)");
+
+    if host_triple == target {
+        println!("cargo:rustc-cfg=native");
+    }
+
     if backends.len() > 1 {
         println!("cargo::error=More than one backend selected: {backends:?}");
         return;

--- a/rtic/src/export/cortex_basepri.rs
+++ b/rtic/src/export/cortex_basepri.rs
@@ -1,5 +1,3 @@
-use super::cortex_logical2hw;
-use cortex_m::register::{basepri, basepri_max};
 pub use cortex_m::{
     Peripherals,
     asm::wfi,
@@ -7,6 +5,13 @@ pub use cortex_m::{
     peripheral::{DWT, SCB, SYST, scb::SystemHandler},
 };
 
+#[cfg(not(native))]
+use super::cortex_logical2hw;
+
+#[cfg(not(native))]
+use cortex_m::register::{basepri, basepri_max};
+
+#[cfg(not(native))]
 #[inline(always)]
 pub fn run<F>(priority: u8, f: F)
 where
@@ -58,6 +63,7 @@ where
 /// but can in theory be fixed.
 ///
 #[inline(always)]
+#[cfg(not(native))]
 pub unsafe fn lock<T, R>(
     ptr: *mut T,
     ceiling: u8,
@@ -75,4 +81,17 @@ pub unsafe fn lock<T, R>(
             r
         }
     }
+}
+
+#[cfg(native)]
+pub fn run<F>(_prio: u8, _f: F)
+where
+    F: FnOnce(),
+{
+    unimplemented!();
+}
+
+#[cfg(native)]
+pub unsafe fn lock<T, R>(_ptr: *mut T, _ceil: u8, _prio: u8, _f: impl FnOnce(&mut T) -> R) -> R {
+    unimplemented!();
 }


### PR DESCRIPTION
cortex-m is supposed to re-export these registers, but the latest patch release doesn't do that anymore.

They might fix it, or might not. Fix it in-place for the time being.

See: https://github.com/rust-embedded/cortex-m/issues/680