### PR TITLE
Fix #1225

### DIFF
--- a/rtic-macros/CHANGELOG.md
+++ b/rtic-macros/CHANGELOG.md
@@ -15,6 +15,10 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 - `local_task` arguments can be patterns instead of just an ident.
 - The `local_task = true` argument to `#[task]` must no longer be the last argument.
 
+### Fixed
+
+- Previously, non-diverging `extern "Rust"` tasks could have a `Context` with a `<'static>` lifetime. This is no longer allowed.
+
 ## [v2.3.0] - 2026-07-08
 
 ### Fixed

--- a/rtic-macros/src/codegen/hardware_tasks.rs
+++ b/rtic-macros/src/codegen/hardware_tasks.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::Lifetime;
 
 /// Generate support code for hardware tasks (`#[exception]`s and `#[interrupt]`s)
 pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
@@ -24,6 +25,8 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
         let exit_stmts = interrupt_exit(app, analysis);
         let config = handler_config(app, analysis, symbol.clone());
 
+        let lifetime = Lifetime::new("'non_static", name.span());
+
         mod_app.push(quote!(
             #[allow(non_snake_case)]
             #[no_mangle]
@@ -35,11 +38,12 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
 
                 const PRIORITY: u8 = #priority;
 
-                rtic::export::run(PRIORITY, || {
-                    #name(
-                        #name::Context::new()
-                    )
-                });
+                fn exec<#lifetime>() {
+                    let ctx = unsafe { #name::Context::<#lifetime>::new() };
+                    #name(ctx)
+                }
+
+                rtic::export::run(PRIORITY, exec);
 
                 #(#exit_stmts)*
             }

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -145,8 +145,18 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
 
         let lifetime = Lifetime::new("'non_static", name.span());
 
-        let spawn = if app.software_tasks[t].is_bottom || !app.software_tasks[t].is_extern {
-            quote! { exec.spawn(#name(unsafe { #name::Context::new() } #(,#input_untupled)*)); }
+        let task = &app.software_tasks[t];
+        let spawn = if !task.is_extern {
+            quote! {
+                let future = #name(unsafe { #name::Context::new() } #(,#input_untupled)*);
+                exec.spawn(future);
+            }
+        } else if task.is_bottom {
+            quote! {
+                let future = #name(unsafe { #name::Context::new() } #(,#input_untupled)*);
+                let future = rtic::export::executor::assert_task_diverges(future);
+                exec.spawn(future);
+            }
         } else {
             quote! {
                 // First, create a context with a bound lifetime (i.e. non-`'static`) to

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -145,8 +145,18 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
 
         let lifetime = Lifetime::new("'non_static", name.span());
 
-        let spawn = if app.software_tasks[t].is_bottom || !app.software_tasks[t].is_extern {
-            quote! { exec.spawn(#name(unsafe { #name::Context::new() } #(,#input_untupled)*)); }
+        let task = &app.software_tasks[t];
+        let spawn = if !task.is_extern {
+            quote! {
+                let future = #name(unsafe { #name::Context::new() } #(,#input_untupled)*);
+                exec.spawn(future);
+            }
+        } else if task.is_bottom {
+            quote! {
+                let future = #name(unsafe { #name::Context::new() } #(,#input_untupled)*);
+                let future = rtic::export::executor::assert_future_diverges(future);
+                exec.spawn(future);
+            }
         } else {
             quote! {
                 // First, create a context with a bound lifetime (i.e. non-`'static`) to

--- a/rtic-macros/src/codegen/module.rs
+++ b/rtic-macros/src/codegen/module.rs
@@ -3,6 +3,7 @@ use crate::{analyze::Analysis, codegen::bindings::interrupt_mod, codegen::util};
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::Lifetime;
 
 #[allow(clippy::too_many_lines)]
 pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
@@ -142,18 +143,39 @@ pub fn codegen(ctxt: Context, app: &App, analysis: &Analysis) -> TokenStream2 {
             quote! {}
         };
 
+        let lifetime = Lifetime::new("'non_static", name.span());
+
+        let spawn = if app.software_tasks[t].is_bottom || !app.software_tasks[t].is_extern {
+            quote! { exec.spawn(#name(unsafe { #name::Context::new() } #(,#input_untupled)*)); }
+        } else {
+            quote! {
+                // First, create a context with a bound lifetime (i.e. non-`'static`) to
+                // pass to the non-diverging task.
+                let ctx = unsafe { #name::Context::<#lifetime>::new() };
+                let future = #name(ctx #(,#input_untupled)*);
+                // The executor requires a future that is `'static`, but really
+                // just one that is valid for the duration of the context's validity,
+                // which is until the `Future` returns `Poll::Done`. Since the `future`
+                // we created cannot have a lifetime longer than the `Context`, we can
+                // `transmute` the future into a `'static` future.
+                let future = unsafe { core::mem::transmute(future) };
+                exec.spawn(future);
+            }
+        };
+
         // Spawn caller
         items.push(quote!(
             #(#cfgs)*
             /// Spawns the task directly
             #[allow(non_snake_case)]
             #[doc(hidden)]
-            pub #unsafety fn #internal_spawn_ident(#(#input_args,)*) -> ::core::result::Result<(), #input_ty> {
+            #[allow(clippy::extra_unused_lifetimes)]
+            pub #unsafety fn #internal_spawn_ident<#lifetime>(#(#input_args,)*) -> ::core::result::Result<(), #input_ty> {
                 // SAFETY: If `try_allocate` succeeds one must call `spawn`, which we do.
                 unsafe {
                     let exec = rtic::export::executor::AsyncTaskExecutor::#from_ptr_n_args(#name, &#exec_name);
                     if exec.try_allocate() {
-                        exec.spawn(#name(unsafe { #name::Context::new() } #(,#input_untupled)*));
+                        #spawn
                         #pend_interrupt
 
                         Ok(())

--- a/rtic-macros/src/codegen/software_tasks.rs
+++ b/rtic-macros/src/codegen/software_tasks.rs
@@ -48,11 +48,17 @@ pub fn codegen(app: &App, analysis: &Analysis) -> TokenStream2 {
                 quote!(<'a>)
             };
 
+            let output = if task.is_bottom {
+                quote!(-> !)
+            } else {
+                quote!()
+            };
+
             user_tasks.push(quote!(
                 #(#attrs)*
                 #(#cfgs)*
                 #[allow(non_snake_case)]
-                async fn #name #generics(#context: #name::Context<#lifetime> #(,#inputs)*) {
+                async fn #name #generics(#context: #name::Context<#lifetime> #(,#inputs)*) #output {
                     use rtic::Mutex as _;
                     use rtic::mutex::prelude::*;
 

--- a/rtic-macros/src/syntax/parse/hardware_task.rs
+++ b/rtic-macros/src/syntax/parse/hardware_task.rs
@@ -16,7 +16,7 @@ impl HardwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name, false) {
                 if rest.is_empty() {
                     let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
@@ -52,7 +52,7 @@ impl HardwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name, false) {
                 if rest.is_empty() {
                     let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 

--- a/rtic-macros/src/syntax/parse/hardware_task.rs
+++ b/rtic-macros/src/syntax/parse/hardware_task.rs
@@ -1,6 +1,6 @@
 use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
-use crate::syntax::parse::util::FilterAttrs;
+use crate::syntax::parse::util::{FilterAttrs, TaskType};
 use crate::syntax::{
     ast::{HardwareTask, HardwareTaskArgs},
     parse::util,
@@ -16,7 +16,9 @@ impl HardwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) =
+                util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+            {
                 if rest.is_empty() {
                     let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
@@ -52,7 +54,9 @@ impl HardwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) =
+                util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+            {
                 if rest.is_empty() {
                     let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 

--- a/rtic-macros/src/syntax/parse/idle.rs
+++ b/rtic-macros/src/syntax/parse/idle.rs
@@ -3,7 +3,7 @@ use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
 use crate::syntax::{
     ast::{Idle, IdleArgs},
-    parse::util,
+    parse::util::{self, TaskType},
 };
 
 impl IdleArgs {
@@ -21,7 +21,9 @@ impl Idle {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) =
+                util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+            {
                 if rest.is_empty() {
                     return Ok(Idle {
                         args,
@@ -49,7 +51,9 @@ impl Idle {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) =
+                util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+            {
                 if rest.is_empty() {
                     return Ok(Idle {
                         args,

--- a/rtic-macros/src/syntax/parse/idle.rs
+++ b/rtic-macros/src/syntax/parse/idle.rs
@@ -21,7 +21,7 @@ impl Idle {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name, false) {
                 if rest.is_empty() {
                     return Ok(Idle {
                         args,
@@ -49,7 +49,7 @@ impl Idle {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name, false) {
                 if rest.is_empty() {
                     return Ok(Idle {
                         args,

--- a/rtic-macros/src/syntax/parse/init.rs
+++ b/rtic-macros/src/syntax/parse/init.rs
@@ -1,4 +1,4 @@
-use crate::syntax::TokenStream2;
+use crate::syntax::{parse::util::TaskType, TokenStream2};
 use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
 use crate::syntax::{
@@ -24,7 +24,9 @@ impl Init {
             if let Ok((user_shared_struct, user_local_struct)) =
                 util::type_is_init_return(&item.sig.output)
             {
-                if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+                if let Some((context, Ok(rest))) =
+                    util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+                {
                     if rest.is_empty() {
                         return Ok(Init {
                             args,
@@ -61,7 +63,9 @@ impl Init {
             if let Ok((user_shared_struct, user_local_struct)) =
                 util::type_is_init_return(&item.sig.output)
             {
-                if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+                if let Some((context, Ok(rest))) =
+                    util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+                {
                     if rest.is_empty() {
                         return Ok(Init {
                             args,

--- a/rtic-macros/src/syntax/parse/init.rs
+++ b/rtic-macros/src/syntax/parse/init.rs
@@ -24,7 +24,8 @@ impl Init {
             if let Ok((user_shared_struct, user_local_struct)) =
                 util::type_is_init_return(&item.sig.output)
             {
-                if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+                if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name, false)
+                {
                     if rest.is_empty() {
                         return Ok(Init {
                             args,
@@ -61,7 +62,8 @@ impl Init {
             if let Ok((user_shared_struct, user_local_struct)) =
                 util::type_is_init_return(&item.sig.output)
             {
-                if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
+                if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name, false)
+                {
                     if rest.is_empty() {
                         return Ok(Init {
                             args,

--- a/rtic-macros/src/syntax/parse/software_task.rs
+++ b/rtic-macros/src/syntax/parse/software_task.rs
@@ -18,7 +18,9 @@ impl SoftwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(inputs))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(inputs))) =
+                util::parse_inputs(item.sig.inputs, &name, false /* not extern */)
+            {
                 let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                 return Ok(SoftwareTask {
@@ -57,7 +59,9 @@ impl SoftwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(inputs))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(inputs))) =
+                util::parse_inputs(item.sig.inputs, &name, !is_bottom)
+            {
                 let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                 return Ok(SoftwareTask {
@@ -75,7 +79,7 @@ impl SoftwareTask {
 
         Err(parse::Error::new(
             span,
-            format!("this task handler must have type signature `async fn({name}::Context, ..)` or `async fn({name}::Context, ..) -> !`"),
+            format!("this task handler must have type signature `async fn({name}::Context<'_>, ..)` or `async fn({name}::Context<'static>, ..) -> !`"),
         ))
     }
 }

--- a/rtic-macros/src/syntax/parse/software_task.rs
+++ b/rtic-macros/src/syntax/parse/software_task.rs
@@ -1,6 +1,6 @@
 use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
-use crate::syntax::parse::util::FilterAttrs;
+use crate::syntax::parse::util::{FilterAttrs, TaskType};
 use crate::syntax::{
     ast::{SoftwareTask, SoftwareTaskArgs},
     parse::util,
@@ -18,7 +18,9 @@ impl SoftwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(inputs))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(inputs))) =
+                util::parse_inputs(item.sig.inputs, &name, TaskType::Other)
+            {
                 let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                 return Ok(SoftwareTask {
@@ -48,6 +50,12 @@ impl SoftwareTask {
     ) -> parse::Result<Self> {
         let is_bottom = util::type_is_bottom(&item.sig.output);
 
+        let task_type = if !is_bottom {
+            TaskType::SoftwareExternNotBottom
+        } else {
+            TaskType::Other
+        };
+
         let valid_signature = util::check_foreign_fn_signature(&item, true)
             && (util::type_is_unit(&item.sig.output) || is_bottom)
             && item.sig.asyncness.is_some();
@@ -57,7 +65,9 @@ impl SoftwareTask {
         let name = item.sig.ident.to_string();
 
         if valid_signature {
-            if let Some((context, Ok(inputs))) = util::parse_inputs(item.sig.inputs, &name) {
+            if let Some((context, Ok(inputs))) =
+                util::parse_inputs(item.sig.inputs, &name, task_type)
+            {
                 let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                 return Ok(SoftwareTask {
@@ -75,7 +85,7 @@ impl SoftwareTask {
 
         Err(parse::Error::new(
             span,
-            format!("this task handler must have type signature `async fn({name}::Context, ..)` or `async fn({name}::Context, ..) -> !`"),
+            format!("this task handler must have type signature `async fn({name}::Context<'_>, ..)` or `async fn({name}::Context<'static>, ..) -> !`"),
         ))
     }
 }

--- a/rtic-macros/src/syntax/parse/util.rs
+++ b/rtic-macros/src/syntax/parse/util.rs
@@ -4,7 +4,7 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     Abi, AttrStyle, Attribute, Expr, ExprPath, FnArg, ForeignItemFn, Ident, ItemFn, Pat, PatType,
-    Path, PathArguments, ReturnType, Token, Type, Visibility,
+    Path, PathArguments, PathSegment, ReturnType, Token, Type, Visibility,
 };
 
 use crate::syntax::{
@@ -282,12 +282,16 @@ pub fn parse_local_resources(content: ParseStream<'_>) -> parse::Result<LocalRes
 
 type ParseInputResult = Option<(Box<Pat>, Result<Vec<PatType>, FnArg>)>;
 
-pub fn parse_inputs(inputs: Punctuated<FnArg, Token![,]>, name: &str) -> ParseInputResult {
+pub fn parse_inputs(
+    inputs: Punctuated<FnArg, Token![,]>,
+    name: &str,
+    extern_and_not_bottom: bool,
+) -> ParseInputResult {
     let mut inputs = inputs.into_iter();
 
     match inputs.next() {
         Some(FnArg::Typed(first)) => {
-            if type_is_path(&first.ty, &[name, "Context"]) {
+            if is_valid_context(&first.ty, &[name, "Context"], extern_and_not_bottom) {
                 let rest = inputs
                     .map(|arg| match arg {
                         FnArg::Typed(arg) => Ok(arg),
@@ -358,18 +362,47 @@ pub fn type_is_init_return(ty: &ReturnType) -> Result<(Ident, Ident), ()> {
     }
 }
 
-pub fn type_is_path(ty: &Type, segments: &[&str]) -> bool {
+pub fn is_valid_context(ty: &Type, segments: &[&str], extern_and_not_bottom: bool) -> bool {
     match ty {
         Type::Path(tpath) if tpath.qself.is_none() => {
-            tpath.path.segments.len() == segments.len()
+            let is_valid_path = tpath.path.segments.len() == segments.len()
                 && tpath
                     .path
                     .segments
                     .iter()
                     .zip(segments)
-                    .all(|(lhs, rhs)| lhs.ident == **rhs)
-        }
+                    .all(|(lhs, rhs)| lhs.ident == **rhs);
 
+            // If not extern or bottom, allow any lifetime. If extern and
+            // not bottom, restrict the lifetime.
+            let allowed_lifetime = !extern_and_not_bottom
+                || match &tpath.path.segments.last() {
+                    Some(PathSegment {
+                        arguments: PathArguments::AngleBracketed(args),
+                        ..
+                    }) => {
+                        if args.args.is_empty() {
+                            true
+                        } else if args.args.len() != 1 {
+                            false
+                        } else {
+                            match args.args.last() {
+                                Some(syn::GenericArgument::Lifetime(lifetime)) => {
+                                    lifetime.ident != "static"
+                                }
+                                _ => false,
+                            }
+                        }
+                    }
+                    Some(PathSegment {
+                        arguments: PathArguments::None,
+                        ..
+                    }) => true,
+                    _ => false,
+                };
+
+            is_valid_path && allowed_lifetime
+        }
         _ => false,
     }
 }

--- a/rtic-macros/src/syntax/parse/util.rs
+++ b/rtic-macros/src/syntax/parse/util.rs
@@ -4,7 +4,7 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     Abi, AttrStyle, Attribute, Expr, ExprPath, FnArg, ForeignItemFn, Ident, ItemFn, Pat, PatType,
-    Path, PathArguments, ReturnType, Token, Type, Visibility,
+    Path, PathArguments, PathSegment, ReturnType, Token, Type, Visibility,
 };
 
 use crate::syntax::{
@@ -280,14 +280,27 @@ pub fn parse_local_resources(content: ParseStream<'_>) -> parse::Result<LocalRes
     Ok(resources)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TaskType {
+    /// A software task, with an `extern "Rust"` definition, that
+    /// does not return `!`.
+    SoftwareExternNotBottom,
+    /// All other tasks types.
+    Other,
+}
+
 type ParseInputResult = Option<(Box<Pat>, Result<Vec<PatType>, FnArg>)>;
 
-pub fn parse_inputs(inputs: Punctuated<FnArg, Token![,]>, name: &str) -> ParseInputResult {
+pub fn parse_inputs(
+    inputs: Punctuated<FnArg, Token![,]>,
+    name: &str,
+    task_type: TaskType,
+) -> ParseInputResult {
     let mut inputs = inputs.into_iter();
 
     match inputs.next() {
         Some(FnArg::Typed(first)) => {
-            if type_is_path(&first.ty, &[name, "Context"]) {
+            if is_valid_context(&first.ty, &[name, "Context"], task_type) {
                 let rest = inputs
                     .map(|arg| match arg {
                         FnArg::Typed(arg) => Ok(arg),
@@ -358,18 +371,47 @@ pub fn type_is_init_return(ty: &ReturnType) -> Result<(Ident, Ident), ()> {
     }
 }
 
-pub fn type_is_path(ty: &Type, segments: &[&str]) -> bool {
+pub fn is_valid_context(ty: &Type, segments: &[&str], task_ty: TaskType) -> bool {
     match ty {
         Type::Path(tpath) if tpath.qself.is_none() => {
-            tpath.path.segments.len() == segments.len()
+            let is_valid_path = tpath.path.segments.len() == segments.len()
                 && tpath
                     .path
                     .segments
                     .iter()
                     .zip(segments)
-                    .all(|(lhs, rhs)| lhs.ident == **rhs)
-        }
+                    .all(|(lhs, rhs)| lhs.ident == **rhs);
 
+            // If this is a software task that does not return `!`, restrict
+            // the lifetime.
+            let allowed_lifetime = task_ty == TaskType::Other
+                || match &tpath.path.segments.last() {
+                    Some(PathSegment {
+                        arguments: PathArguments::AngleBracketed(args),
+                        ..
+                    }) => {
+                        if args.args.is_empty() {
+                            true
+                        } else if args.args.len() != 1 {
+                            false
+                        } else {
+                            match args.args.last() {
+                                Some(syn::GenericArgument::Lifetime(lifetime)) => {
+                                    lifetime.ident != "static"
+                                }
+                                _ => false,
+                            }
+                        }
+                    }
+                    Some(PathSegment {
+                        arguments: PathArguments::None,
+                        ..
+                    }) => true,
+                    _ => false,
+                };
+
+            is_valid_path && allowed_lifetime
+        }
         _ => false,
     }
 }

--- a/rtic-macros/ui/extern-non-diverging-no-static-ctx.rs
+++ b/rtic-macros/ui/extern-non-diverging-no-static-ctx.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+#[rtic_macros::mock_app(device = mock, dispatchers = [EXTI0])]
+mod app {
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local) {
+        todo!()
+    }
+
+    extern "Rust" {
+        #[task]
+        async fn foo(_: foo::Context<'static>);
+    }
+}

--- a/rtic-macros/ui/extern-non-diverging-no-static-ctx.stderr
+++ b/rtic-macros/ui/extern-non-diverging-no-static-ctx.stderr
@@ -1,0 +1,5 @@
+error: this task handler must have type signature `async fn(foo::Context<'_>, ..)` or `async fn(foo::Context<'static>, ..) -> !`
+  --> ui/extern-non-diverging-no-static-ctx.rs:18:18
+   |
+18 |         async fn foo(_: foo::Context<'static>);
+   |                  ^^^

--- a/rtic/CHANGELOG.md
+++ b/rtic/CHANGELOG.md
@@ -25,6 +25,10 @@ Example:
 - Removed `cortex-m`, `esp32c3`, `esp32c6`, `riscv`, and `riscv-slic` features. These were all implicit features from dependencies that should only be activated by selecting a backend.
 - Removed `test-critical-section` feature
 
+### Fixed
+
+- Previously, non-diverging `extern "Rust"` tasks could have a `Context` with a `<'static>` lifetime. This is no longer allowed.
+
 ## [v2.3.0] - 2026-07-08
 
 ### Added

--- a/rtic/src/export/executor.rs
+++ b/rtic/src/export/executor.rs
@@ -1,6 +1,7 @@
 use super::atomic::{AtomicBool, AtomicPtr, Ordering};
 use core::{
     cell::UnsafeCell,
+    convert::Infallible,
     future::Future,
     mem::{self, ManuallyDrop, MaybeUninit},
     pin::Pin,
@@ -213,4 +214,17 @@ impl<F: Future + 'static> AsyncTaskExecutor<F> {
             }
         }
     }
+}
+
+/// This function is used to assert that tasks that
+/// return `!` are backed by functions that return `!`.
+///
+/// The only type that implements `Into<Infallible>` is
+/// `!`.
+pub fn assert_future_diverges<F, I>(f: F) -> F
+where
+    I: Into<Infallible>,
+    F: Future<Output = I>,
+{
+    f
 }

--- a/rtic/src/export/executor.rs
+++ b/rtic/src/export/executor.rs
@@ -1,6 +1,7 @@
 use super::atomic::{AtomicBool, AtomicPtr, Ordering};
 use core::{
     cell::UnsafeCell,
+    convert::Infallible,
     future::Future,
     mem::{self, ManuallyDrop, MaybeUninit},
     pin::Pin,
@@ -213,4 +214,17 @@ impl<F: Future + 'static> AsyncTaskExecutor<F> {
             }
         }
     }
+}
+
+/// This function is used to assert that tasks that
+/// return `!` are backed by functions that return `!`.
+///
+/// The only type that implements `Into<Infallible>` is
+/// `!`.
+pub fn assert_task_diverges<F, I>(f: F) -> F
+where
+    I: Into<Infallible>,
+    F: Future<Output = I>,
+{
+    f
 }


### PR DESCRIPTION
For this to function correctly, we must 

Assert that `extern` software tasks are one of two things:

* An `async fn` with a `Context<'a>` where `'a != 'static`
* An `async fn` that returns `!`

and

Assert that `extern` hardware tasks are an `fn` with a `Context<'a>` where `'a != 'static`.

All other tasks (not `extern` or non-divergent) are left along.

This PR adds two layers of validation: in `extern "Rust"` blocks, checks that the signature is correct (i.e. non-divergent tasks must not have `Context<'static>`), and for spawning code of `extern` tasks it validates that the lifetime of the to-be-spawned-future is non-`static`, or that the returned future is divergent.

Checking that a future is divergent is done using an `Into<Infallible>` hack. The DX isn't great, but there doesn't seem to be any other way to name the `!` requirement.

Sadly it doesn't seem like we can test much of this fully: the testing infra (= UI tests) doesn't support `extern "Rust"` tasks.

Fixes #1225 

A test example that showcases all the errors:

<details>
<summary>An example for lm3s6965 showing the caught cases</summary>

```rust
#![no_main]
#![no_std]

use panic_semihosting as _;

#[rtic::app(device = lm3s6965)]
mod app {
    use super::*;

    #[shared]
    struct Shared {}

    #[local]
    struct Local {}

    #[init]
    fn init(_: init::Context) -> (Shared, Local) {
        todo!()
    }

    extern "Rust" {
        // Error cases
        // These two we can check in the macro
        #[task]
        async fn non_diverging_static(_: non_diverging_static::Context<'static>);

        #[task(binds = GPIOA)]
        fn hw_task_static(_: hw_task::Context<'static>);

        // These three can only be checked by the compiler
        #[task]
        async fn extern_doesnt_diverge(_: extern_doesnt_diverge::Context<'_>) -> !;

        #[task]
        async fn extern_requires_static(_: extern_requires_static::Context<'_>);

        #[task(binds = GPIOA)]
        fn hw_task_extern_static(_: hw_task_extern_static::Context);

        // Accepted cases
        #[task]
        async fn non_diverging_non_static(_: non_diverging_non_static::Context<'_>);

        #[task]
        async fn non_diverging_no_lt(_: non_diverging_no_lt::Context);

        #[task]
        async fn diverging_static(_: diverging_static::Context<'static>) -> !;

        // NOTE: we don't (and don't need to) validate whether the actual function
        // definition uses <'static>.
        #[task]
        async fn diverging_non_static(_: diverging_non_static::Context<'_>) -> !;

        // NOTE: we don't (and don't need to) validate whether the actual function
        // definition uses <'static>.
        #[task]
        async fn diverging_no_lt(_: diverging_no_lt::Context) -> !;
    }
}

use app::*;

fn hw_task_extern_static(_: hw_task_extern_static::Context<'static>) {}

async fn extern_doesnt_diverge(_: extern_doesnt_diverge::Context<'_>) {
    loop {}
}

async fn extern_requires_static(_: extern_requires_static::Context<'static>) {}

async fn non_diverging_non_static(_: non_diverging_non_static::Context<'_>) {}

async fn non_diverging_no_lt(_: non_diverging_no_lt::Context<'_>) {}

async fn diverging_static(_: diverging_static::Context<'static>) -> ! {
    loop {}
}

async fn diverging_non_static(_: diverging_non_static::Context<'_>) -> ! {
    loop {}
}

async fn diverging_no_lt(_: diverging_no_lt::Context<'_>) -> ! {
    loop {}
}

```

</details>