### PR TITLE
Use version range to work around `cortex-m v0.7.8` bug.

### DIFF
--- a/examples/lm3s6965/Cargo.lock
+++ b/examples/lm3s6965/Cargo.lock
@@ -50,15 +50,28 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
+checksum = "f985670a83ddb4c96174f696987458ae26fe3d801faf7263b56a2b2252c2f76f"
 dependencies = [
  "bare-metal",
  "bitfield",
+ "cortex-m-macros",
  "critical-section",
  "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
  "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-macros"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1922be58519ad40368fc4ca595a2cefa51a7abf947be3b0c90586dc7dbd0e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rtic/Cargo.toml
+++ b/rtic/Cargo.toml
@@ -38,6 +38,8 @@ critical-section = "1"
 [dev-dependencies]
 lm3s6965 = "0.2"
 cortex-m-semihosting = "0.6.0"
+# 0.7.8 contains a bug that breaks builds for std targets.
+cortex-m = ">=0.7.0,<=0.7.7"
 rtic-sync = { path = "../rtic-sync" }
 
 [dev-dependencies.futures]

--- a/rtic/build.rs
+++ b/rtic/build.rs
@@ -13,16 +13,6 @@ fn main() {
     // Get the backend feature selected by the user
     let mut backends: Vec<_> = backends().collect();
 
-    // Temporary workaround for https://github.com/rust-embedded/cortex-m/issues/680
-    let target = env::var("TARGET").unwrap();
-    let host_triple = env::var("HOST").unwrap();
-
-    println!("cargo::rustc-check-cfg=cfg(native)");
-
-    if host_triple == target {
-        println!("cargo:rustc-cfg=native");
-    }
-
     if backends.len() > 1 {
         println!("cargo::error=More than one backend selected: {backends:?}");
         return;

--- a/rtic/src/export/cortex_basepri.rs
+++ b/rtic/src/export/cortex_basepri.rs
@@ -1,3 +1,5 @@
+use super::cortex_logical2hw;
+use cortex_m::register::{basepri, basepri_max};
 pub use cortex_m::{
     Peripherals,
     asm::wfi,
@@ -5,13 +7,6 @@ pub use cortex_m::{
     peripheral::{DWT, SCB, SYST, scb::SystemHandler},
 };
 
-#[cfg(not(native))]
-use super::cortex_logical2hw;
-
-#[cfg(not(native))]
-use cortex_m::register::{basepri, basepri_max};
-
-#[cfg(not(native))]
 #[inline(always)]
 pub fn run<F>(priority: u8, f: F)
 where
@@ -63,7 +58,6 @@ where
 /// but can in theory be fixed.
 ///
 #[inline(always)]
-#[cfg(not(native))]
 pub unsafe fn lock<T, R>(
     ptr: *mut T,
     ceiling: u8,
@@ -81,17 +75,4 @@ pub unsafe fn lock<T, R>(
             r
         }
     }
-}
-
-#[cfg(native)]
-pub fn run<F>(_prio: u8, _f: F)
-where
-    F: FnOnce(),
-{
-    unimplemented!();
-}
-
-#[cfg(native)]
-pub unsafe fn lock<T, R>(_ptr: *mut T, _ceil: u8, _prio: u8, _f: impl FnOnce(&mut T) -> R) -> R {
-    unimplemented!();
 }


### PR DESCRIPTION
Instead of working around the bug with extra code, we can get rid of the extra code and "just" place an extra version range on the version of `cortex-m` in our dev-dependencies.

This will mean that downstream crates attempting to compile `rtic` for a native (i.e. not armv7 or armv8) will also get compilation errors if they do not apply this bound, but perhaps we can live with that.

Reverts #1224 